### PR TITLE
feat: support Gemini Nano on-device translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/background/library/pageTranslate.js
+++ b/packages/EdgeTranslate/src/background/library/pageTranslate.js
@@ -11,7 +11,8 @@ function translatePage(channel) {
     getOrSetDefaultSettings(["DefaultPageTranslator", "languageSetting"], DEFAULT_SETTINGS).then(
         (result) => {
             const translator = result.DefaultPageTranslator;
-            // const targetLang = (result.languageSetting && result.languageSetting.tl) || "en";
+            const targetLang = (result.languageSetting && result.languageSetting.tl) || "en";
+            const sourceLang = (result.languageSetting && result.languageSetting.sl) || "auto";
 
             // Page translation is currently Chrome-only.
             if (!FEATURE_FLAGS.pageTranslate) return;
@@ -20,12 +21,25 @@ function translatePage(channel) {
                 case "GooglePageTranslate":
                     executeGoogleScript(channel);
                     break;
+                case "GeminiNanoPageTranslate":
+                    executeDomPageTranslate(channel, {
+                        engine: "geminiNano",
+                        sl: sourceLang,
+                        tl: targetLang,
+                    });
+                    break;
+                case "ChromeBuiltinPageTranslate":
+                    executeDomPageTranslate(channel, {
+                        engine: "chromeBuiltin",
+                        sl: sourceLang,
+                        tl: targetLang,
+                    });
+                    break;
                 case "DomPageTranslate":
-                    // Safari 외 브라우저에서만 사용
-                    promiseTabs.query({ active: true, currentWindow: true }).then((tabs) => {
-                        if (tabs && tabs[0]) {
-                            channel.emitToTabs(tabs[0].id, "start_dom_page_translate", {});
-                        }
+                    executeDomPageTranslate(channel, {
+                        engine: "dom",
+                        sl: sourceLang,
+                        tl: targetLang,
                     });
                     break;
                 default:
@@ -34,6 +48,20 @@ function translatePage(channel) {
             }
         }
     );
+}
+
+/**
+ * Execute DOM-based page translation in the active tab.
+ *
+ * @param {import("../../common/scripts/channel.js").default} channel Communication channel.
+ * @param {{ engine?: string, sl?: string, tl?: string }} detail Page translation options.
+ */
+function executeDomPageTranslate(channel, detail = {}) {
+    promiseTabs.query({ active: true, currentWindow: true }).then((tabs) => {
+        if (tabs && tabs[0]) {
+            channel.emitToTabs(tabs[0].id, "start_dom_page_translate", detail);
+        }
+    });
 }
 
 /**
@@ -77,4 +105,4 @@ function executeGoogleScript(channel) {
     });
 }
 
-export { translatePage, executeGoogleScript };
+export { translatePage, executeGoogleScript, executeDomPageTranslate };

--- a/packages/EdgeTranslate/src/background/library/translate.js
+++ b/packages/EdgeTranslate/src/background/library/translate.js
@@ -2,6 +2,10 @@ import { HybridTranslator } from "@edge_translate/translators";
 // common.log는 현재 파일에서 직접 사용하지 않습니다.
 import { promiseTabs, delayPromise } from "common/scripts/promise.js";
 import { DEFAULT_SETTINGS, getOrSetDefaultSettings } from "common/scripts/settings.js";
+import {
+    getChromeTranslatorSupportedLanguages,
+    getGeminiNanoSupportedLanguages,
+} from "common/scripts/chrome_builtin_translate.js";
 import TtlCache from "./ttlCache.js";
 import { executeGoogleScript } from "./pageTranslate.js";
 
@@ -34,6 +38,11 @@ class TranslatorManager {
                 channel,
                 configs.LocalTranslatorConfig
             );
+            this.localTranslatorProxy = this.createLocalTranslatorProxy(
+                this.HYBRID_TRANSLATOR.REAL_TRANSLATORS.LocalTranslate,
+                configs.LocalTranslatorConfig
+            );
+            this.HYBRID_TRANSLATOR.REAL_TRANSLATORS.LocalTranslate = this.localTranslatorProxy;
 
             // Supported translators.
             this.TRANSLATORS = {
@@ -67,12 +76,73 @@ class TranslatorManager {
         this.translationCache = new TtlCache({ maxEntries: this.cacheOptions.maxEntries });
         this.inflightDetect = new Map(); // key -> Promise
         this.inflightTranslate = new Map(); // key -> Promise
+        this.currentChromeBuiltinTabId = null;
 
         /**
          * Start to provide services and listen to event.
          */
         this.provideServices();
         this.listenToEvents();
+    }
+
+    /**
+     * Clear caches when configuration or language settings change
+     */
+    createLocalTranslatorProxy(endpointTranslator, initialConfig = {}) {
+        let config = initialConfig || {};
+        const manager = this;
+        return {
+            useConfig(nextConfig = {}) {
+                config = nextConfig || {};
+                endpointTranslator.useConfig(nextConfig);
+            },
+            supportedLanguages() {
+                if (!config.enabled) return new Set();
+                if (config.mode === "geminiNano") return getGeminiNanoSupportedLanguages();
+                if (config.mode === "chromeBuiltin") return getChromeTranslatorSupportedLanguages();
+                return endpointTranslator.supportedLanguages();
+            },
+            detect(text) {
+                if (["chromeBuiltin", "geminiNano"].includes(config.mode))
+                    return Promise.resolve("auto");
+                return endpointTranslator.detect(text);
+            },
+            async translate(text, from, to) {
+                if (!["chromeBuiltin", "geminiNano"].includes(config.mode)) {
+                    return endpointTranslator.translate(text, from, to);
+                }
+                const tabId = await manager.getChromeBuiltinTargetTabId();
+                const result = await manager.channel.requestToTab(
+                    tabId,
+                    "chrome_builtin_translate",
+                    {
+                        text,
+                        sl: from,
+                        tl: to,
+                        engine: config.mode,
+                    }
+                );
+                return {
+                    originalText: text,
+                    mainMeaning: result?.mainMeaning || result?.translatedText || "",
+                    translatedText: result?.translatedText || result?.mainMeaning || "",
+                    sourceLanguage: result?.sourceLanguage || from,
+                    targetLanguage: result?.targetLanguage || to,
+                };
+            },
+            pronounce(...args) {
+                return endpointTranslator.pronounce(...args);
+            },
+            stopPronounce(...args) {
+                return endpointTranslator.stopPronounce(...args);
+            },
+        };
+    }
+
+    async getChromeBuiltinTargetTabId() {
+        if (typeof this.currentChromeBuiltinTabId === "number")
+            return this.currentChromeBuiltinTabId;
+        return this.getCurrentTabId();
     }
 
     /**
@@ -155,14 +225,17 @@ class TranslatorManager {
         );
 
         // Quiet single-text translate service for DOM page translation (no UI events)
-        this.channel.provide("translate_text_quiet", async (params) => {
+        this.channel.provide("translate_text_quiet", async (params, sender) => {
             await this.config_loader;
             const text = params && params.text ? params.text : "";
             if (!text) return Promise.resolve({ originalText: "", translatedText: "" });
             let sl = (params && params.sl) || this.LANGUAGE_SETTING.sl || "auto";
             let tl = (params && params.tl) || this.LANGUAGE_SETTING.tl;
+            const translatorId = (params && params.translatorId) || this.DEFAULT_TRANSLATOR;
+            const previousChromeBuiltinTabId = this.currentChromeBuiltinTabId;
+            this.currentChromeBuiltinTabId =
+                sender && sender.tab ? sender.tab.id : previousChromeBuiltinTabId;
             try {
-                const translatorId = this.DEFAULT_TRANSLATOR;
                 // cache first
                 let result = this.getTranslationFromCache(text, sl, tl, translatorId);
                 if (!result) {
@@ -172,6 +245,8 @@ class TranslatorManager {
                 return Promise.resolve(result || { originalText: text, translatedText: text });
             } catch (e) {
                 return Promise.resolve({ originalText: text, translatedText: text });
+            } finally {
+                this.currentChromeBuiltinTabId = previousChromeBuiltinTabId;
             }
         });
 
@@ -432,23 +507,30 @@ class TranslatorManager {
 
             const translatorId = this.DEFAULT_TRANSLATOR;
             const key = this.makeTranslateKey(text, sl, tl, translatorId);
+            const previousChromeBuiltinTabId = this.currentChromeBuiltinTabId;
+            this.currentChromeBuiltinTabId = currentTabId;
 
-            // Try translation cache first
-            let result = this.getTranslationFromCache(text, sl, tl, translatorId);
-            if (!result) {
-                if (this.inflightTranslate.has(key)) {
-                    result = await this.inflightTranslate.get(key);
-                } else {
-                    const promise = this.TRANSLATORS[translatorId]
-                        .translate(text, sl, tl)
-                        .then((res) => {
-                            if (res) this.rememberTranslation(text, sl, tl, translatorId, res);
-                            return res;
-                        })
-                        .finally(() => this.inflightTranslate.delete(key));
-                    this.inflightTranslate.set(key, promise);
-                    result = await promise;
+            let result;
+            try {
+                // Try translation cache first
+                result = this.getTranslationFromCache(text, sl, tl, translatorId);
+                if (!result) {
+                    if (this.inflightTranslate.has(key)) {
+                        result = await this.inflightTranslate.get(key);
+                    } else {
+                        const promise = this.TRANSLATORS[translatorId]
+                            .translate(text, sl, tl)
+                            .then((res) => {
+                                if (res) this.rememberTranslation(text, sl, tl, translatorId, res);
+                                return res;
+                            })
+                            .finally(() => this.inflightTranslate.delete(key));
+                        this.inflightTranslate.set(key, promise);
+                        result = await promise;
+                    }
                 }
+            } finally {
+                this.currentChromeBuiltinTabId = previousChromeBuiltinTabId;
             }
 
             // Ensure language information is always set correctly for TTS

--- a/packages/EdgeTranslate/src/common/scripts/chrome_builtin_translate.js
+++ b/packages/EdgeTranslate/src/common/scripts/chrome_builtin_translate.js
@@ -1,0 +1,269 @@
+/* global globalThis */
+
+const CHROME_TRANSLATOR_LANGUAGE_MAP = {
+    auto: "auto",
+    en: "en",
+    ko: "ko",
+    ja: "ja",
+    "zh-CN": "zh",
+    "zh-TW": "zh-Hant",
+    zh: "zh",
+    fr: "fr",
+    de: "de",
+    es: "es",
+    it: "it",
+    pt: "pt",
+    ru: "ru",
+    vi: "vi",
+    th: "th",
+    id: "id",
+    ar: "ar",
+    hi: "hi",
+    tr: "tr",
+    nl: "nl",
+    pl: "pl",
+    uk: "uk",
+    bg: "bg",
+    bn: "bn",
+    cs: "cs",
+    da: "da",
+    el: "el",
+    fi: "fi",
+    hr: "hr",
+    hu: "hu",
+    iw: "iw",
+    he: "iw",
+    kn: "kn",
+    lt: "lt",
+    mr: "mr",
+    no: "no",
+    ro: "ro",
+    sk: "sk",
+    sl: "sl",
+    sv: "sv",
+    ta: "ta",
+    te: "te",
+};
+
+const LANGUAGE_NAMES = {
+    auto: "auto-detected language",
+    en: "English",
+    ko: "Korean",
+    ja: "Japanese",
+    "zh-CN": "Simplified Chinese",
+    "zh-TW": "Traditional Chinese",
+    zh: "Chinese",
+    fr: "French",
+    de: "German",
+    es: "Spanish",
+    it: "Italian",
+    pt: "Portuguese",
+    ru: "Russian",
+    vi: "Vietnamese",
+    th: "Thai",
+    id: "Indonesian",
+    ar: "Arabic",
+    hi: "Hindi",
+    tr: "Turkish",
+    nl: "Dutch",
+    pl: "Polish",
+    uk: "Ukrainian",
+};
+
+const GEMINI_NANO_SESSION_CACHE = new Map();
+const GEMINI_NANO_MAX_INPUT_CHARS = 4000;
+
+function toChromeTranslatorLanguage(language) {
+    return CHROME_TRANSLATOR_LANGUAGE_MAP[language] || language;
+}
+
+function getChromeTranslatorSupportedLanguages() {
+    return new Set(Object.keys(CHROME_TRANSLATOR_LANGUAGE_MAP));
+}
+
+function getGeminiNanoSupportedLanguages() {
+    return new Set(Object.keys(LANGUAGE_NAMES));
+}
+
+function toLanguageName(language) {
+    return LANGUAGE_NAMES[language] || language || "auto-detected language";
+}
+
+function isChromeBuiltinTranslatorAvailable() {
+    return (
+        typeof globalThis !== "undefined" &&
+        globalThis.Translator &&
+        typeof globalThis.Translator.create === "function"
+    );
+}
+
+function isGeminiNanoLanguageModelAvailable() {
+    return (
+        typeof globalThis !== "undefined" &&
+        globalThis.LanguageModel &&
+        typeof globalThis.LanguageModel.create === "function"
+    );
+}
+
+async function detectChromeBuiltinLanguage(text, targetLanguage) {
+    const detectorApi = globalThis.LanguageDetector;
+    if (!detectorApi || typeof detectorApi.create !== "function") {
+        throw new Error(
+            "Chrome built-in Translator API requires an explicit source language when Language Detector API is unavailable."
+        );
+    }
+
+    const detector = await detectorApi.create();
+    const detections = await detector.detect(text);
+    const detected = Array.isArray(detections) ? detections[0]?.detectedLanguage : undefined;
+    const sourceLanguage = toChromeTranslatorLanguage(detected || "");
+    if (!sourceLanguage || sourceLanguage === targetLanguage) {
+        throw new Error(
+            "Chrome built-in Language Detector API could not determine a translatable source language."
+        );
+    }
+    return sourceLanguage;
+}
+
+async function translateWithChromeBuiltin(text, from, to) {
+    if (!text || !String(text).trim()) {
+        return {
+            originalText: text || "",
+            mainMeaning: "",
+            sourceLanguage: from,
+            targetLanguage: to,
+        };
+    }
+
+    const translatorApi = globalThis.Translator;
+    if (!translatorApi || typeof translatorApi.create !== "function") {
+        throw new Error("Chrome built-in Translator API is not available in this browser context.");
+    }
+
+    const targetLanguage = toChromeTranslatorLanguage(to);
+    const sourceLanguage =
+        from === "auto"
+            ? await detectChromeBuiltinLanguage(text, targetLanguage)
+            : toChromeTranslatorLanguage(from);
+
+    if (typeof translatorApi.availability === "function") {
+        const availability = await translatorApi.availability({ sourceLanguage, targetLanguage });
+        if (availability === "unavailable") {
+            throw new Error(
+                `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+            );
+        }
+    }
+
+    const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+    const translated = await translator.translate(text);
+    if (!translated) {
+        throw new Error("Chrome built-in Translator API returned an empty translation.");
+    }
+
+    return {
+        originalText: text,
+        mainMeaning: translated,
+        translatedText: translated,
+        sourceLanguage,
+        targetLanguage,
+    };
+}
+
+function normalizeGeminiNanoOutput(output) {
+    return String(output || "")
+        .trim()
+        .replace(/^```(?:text)?\s*/i, "")
+        .replace(/```$/i, "")
+        .replace(/^Translation:\s*/i, "")
+        .trim();
+}
+
+async function getGeminiNanoSession(from, to) {
+    const languageModelApi = globalThis.LanguageModel;
+    if (!languageModelApi || typeof languageModelApi.create !== "function") {
+        throw new Error("Chrome Gemini Nano Prompt API is not available in this browser context.");
+    }
+
+    const sourceLanguage = toLanguageName(from);
+    const targetLanguage = toLanguageName(to);
+    const key = `${sourceLanguage}|${targetLanguage}`;
+    if (GEMINI_NANO_SESSION_CACHE.has(key)) return GEMINI_NANO_SESSION_CACHE.get(key);
+
+    if (typeof languageModelApi.availability === "function") {
+        const availability = await languageModelApi.availability();
+        if (availability === "unavailable") {
+            throw new Error("Chrome Gemini Nano model is unavailable on this device.");
+        }
+    }
+
+    const session = await languageModelApi.create({
+        initialPrompts: [
+            {
+                role: "system",
+                content: [
+                    "You are a precise translation engine.",
+                    "Translate user-provided text only.",
+                    "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
+                    "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
+                    `Source language: ${sourceLanguage}.`,
+                    `Target language: ${targetLanguage}.`,
+                ].join("\n"),
+            },
+        ],
+    });
+    GEMINI_NANO_SESSION_CACHE.set(key, session);
+    return session;
+}
+
+async function translateWithGeminiNano(text, from, to) {
+    if (!text || !String(text).trim()) {
+        return {
+            originalText: text || "",
+            mainMeaning: "",
+            sourceLanguage: from,
+            targetLanguage: to,
+        };
+    }
+
+    const session = await getGeminiNanoSession(from, to);
+    const safeText = String(text).slice(0, GEMINI_NANO_MAX_INPUT_CHARS);
+    const sourceLanguage = toLanguageName(from);
+    const targetLanguage = toLanguageName(to);
+    const prompt = [
+        `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
+        "Return only the translated text.",
+        "<text>",
+        safeText,
+        "</text>",
+    ].join("\n");
+    const output = await session.prompt(prompt);
+    const translated = normalizeGeminiNanoOutput(output);
+    if (!translated) {
+        throw new Error("Chrome Gemini Nano returned an empty translation.");
+    }
+
+    return {
+        originalText: text,
+        mainMeaning: translated,
+        translatedText: translated,
+        sourceLanguage: from,
+        targetLanguage: to,
+    };
+}
+
+async function translateWithChromeOnDevice(text, from, to, engine = "geminiNano") {
+    if (engine === "chromeBuiltin") return translateWithChromeBuiltin(text, from, to);
+    return translateWithGeminiNano(text, from, to);
+}
+
+export {
+    getChromeTranslatorSupportedLanguages,
+    getGeminiNanoSupportedLanguages,
+    isChromeBuiltinTranslatorAvailable,
+    isGeminiNanoLanguageModelAvailable,
+    toChromeTranslatorLanguage,
+    translateWithChromeBuiltin,
+    translateWithChromeOnDevice,
+    translateWithGeminiNano,
+};

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -1,5 +1,6 @@
 import Channel from "common/scripts/channel.js";
 import { DEFAULT_SETTINGS, getOrSetDefaultSettings } from "common/scripts/settings.js";
+import { translateWithChromeOnDevice } from "common/scripts/chrome_builtin_translate.js";
 
 /**
  * Control the visibility of page translator banners.
@@ -24,6 +25,10 @@ class BannerController {
         this._translatedSet = new WeakSet();
         this._scheduleBatch = null;
         this._pendingNodes = new Set();
+        this._domPageTranslateOptions = { engine: "dom", sl: "auto", tl: "en" };
+        this._domTranslationCache = new Map();
+        this._domActiveTranslations = 0;
+        this._domMaxConcurrentTranslations = 2;
 
         this.addListeners();
     }
@@ -65,8 +70,22 @@ class BannerController {
             }
         });
 
-        // Kick off DOM fallback on explicit request
-        this.channel.on("start_dom_page_translate", () => {
+        // Provide Chrome on-device translation APIs from a window/content-script context.
+        this.channel.provide("chrome_builtin_translate", async (params) => {
+            const text = params && params.text ? params.text : "";
+            const from = (params && params.sl) || (params && params.from) || "auto";
+            const to = (params && params.tl) || (params && params.to) || "en";
+            const engine = (params && params.engine) || "geminiNano";
+            return translateWithChromeOnDevice(text, from, to, engine);
+        });
+
+        // Kick off DOM fallback/on-device page translation on explicit request
+        this.channel.on("start_dom_page_translate", (detail = {}) => {
+            this._domPageTranslateOptions = {
+                engine: detail.engine || "dom",
+                sl: detail.sl || "auto",
+                tl: detail.tl || "en",
+            };
             this.startDomFallback();
             // initial scan to cover existing content
             const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -274,13 +293,65 @@ class BannerController {
      * Translate a batch of text nodes, marking parents to avoid duplicates.
      */
     translateBatchNodes(nodes) {
-        const parents = new Set();
+        const items = [];
         for (const n of nodes) {
             const p = n.parentElement;
-            if (p && !this._translatedSet.has(p)) parents.add(p);
+            if (!p || this._translatedSet.has(p)) continue;
+            const text = String(n.nodeValue || "").trim();
+            if (text.length < 2) continue;
+            items.push({ node: n, parent: p, text });
+            this._translatedSet.add(p);
+            p.setAttribute("data-et-translated", "1");
         }
-        if (!parents.size) return;
-        parents.forEach((p) => p.setAttribute("data-et-translated", "1"));
+        if (!items.length) return;
+
+        if (!["chromeBuiltin", "geminiNano"].includes(this._domPageTranslateOptions.engine)) return;
+        items.forEach((item) => this.enqueueChromeBuiltinNodeTranslation(item));
+    }
+
+    enqueueChromeBuiltinNodeTranslation(item) {
+        const run = async () => {
+            this._domActiveTranslations += 1;
+            try {
+                const { sl, tl } = this._domPageTranslateOptions;
+                const cacheKey = `${sl}|${tl}|${item.text}`;
+                let translated = this._domTranslationCache.get(cacheKey);
+                if (!translated) {
+                    const result = await translateWithChromeOnDevice(
+                        item.text,
+                        sl,
+                        tl,
+                        this._domPageTranslateOptions.engine
+                    );
+                    translated = result.mainMeaning || result.translatedText;
+                    if (translated) this._domTranslationCache.set(cacheKey, translated);
+                }
+                if (translated && item.node.parentElement === item.parent) {
+                    item.node.nodeValue = translated;
+                }
+            } catch (error) {
+                item.parent.removeAttribute("data-et-translated");
+                this._translatedSet.delete(item.parent);
+            } finally {
+                this._domActiveTranslations -= 1;
+                this.flushDomTranslationQueue();
+            }
+        };
+
+        if (!this._domTranslationQueue) this._domTranslationQueue = [];
+        this._domTranslationQueue.push(run);
+        this.flushDomTranslationQueue();
+    }
+
+    flushDomTranslationQueue() {
+        if (!this._domTranslationQueue) return;
+        while (
+            this._domActiveTranslations < this._domMaxConcurrentTranslations &&
+            this._domTranslationQueue.length
+        ) {
+            const next = this._domTranslationQueue.shift();
+            next();
+        }
     }
 }
 

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.1.0",
+    "version": "3.2.0",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/EdgeTranslate/src/options/options.html
+++ b/packages/EdgeTranslate/src/options/options.html
@@ -183,8 +183,21 @@
                                 setting-path="LocalTranslatorConfig mode"
                                 id="local-translator-mode"
                             >
-                                <option value="endpoint" class="i18n" data-i18n-name="LocalTranslatorModeEndpoint"></option>
-                                <option value="chromeBuiltin" class="i18n" data-i18n-name="LocalTranslatorModeChromeBuiltin"></option>
+                                <option
+                                    value="endpoint"
+                                    class="i18n"
+                                    data-i18n-name="LocalTranslatorModeEndpoint"
+                                ></option>
+                                <option
+                                    value="geminiNano"
+                                    class="i18n"
+                                    data-i18n-name="LocalTranslatorModeGeminiNano"
+                                ></option>
+                                <option
+                                    value="chromeBuiltin"
+                                    class="i18n"
+                                    data-i18n-name="LocalTranslatorModeChromeBuiltin"
+                                ></option>
                             </select>
                         </label>
                     </div>
@@ -303,6 +316,23 @@
                                 class="radio"
                                 name="default-page-translator"
                                 id="google-page-translator"
+                            />
+                        </label>
+                    </div>
+                    <div class="column">
+                        <label
+                            for="gemini-nano-page-translator"
+                            class="checked-label i18n"
+                            data-i18n-name="GeminiNanoPageTranslate"
+                        >
+                            <input
+                                type="radio"
+                                value="GeminiNanoPageTranslate"
+                                setting-type="radio"
+                                setting-path="DefaultPageTranslator"
+                                class="radio"
+                                name="default-page-translator"
+                                id="gemini-nano-page-translator"
                             />
                         </label>
                     </div>
@@ -478,7 +508,6 @@
                             ></label>
                         </div>
                     </div>
-                    
                 </div>
             </div>
             <footer>

--- a/packages/EdgeTranslate/static/_locales/en/messages.json
+++ b/packages/EdgeTranslate/static/_locales/en/messages.json
@@ -1322,5 +1322,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome Built-in",
         "description": "Use Chrome desktop built-in Translator API when available."
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Chrome Gemini Nano Page Translate"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Chrome Built-in Translator Page Translate"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ja/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ja/messages.json
@@ -1322,5 +1322,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome 内蔵",
         "description": "対応するデスクトップ版 Chrome の内蔵 Translator API を使用します。"
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Chrome Gemini Nano ページ翻訳"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Chrome 組み込み翻訳ページ翻訳"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ko/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ko/messages.json
@@ -482,5 +482,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome 내장",
         "description": "지원되는 데스크톱 Chrome의 내장 Translator API를 사용합니다."
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Chrome Gemini Nano 페이지 번역"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Chrome 내장 번역기 페이지 번역"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ru/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ru/messages.json
@@ -1322,5 +1322,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome Built-in",
         "description": "Использовать встроенный Translator API настольного Chrome, если доступен."
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Перевод страницы Chrome Gemini Nano"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Перевод страницы встроенным переводчиком Chrome"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
@@ -1322,5 +1322,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome 内置",
         "description": "使用支持的桌面版 Chrome 内置 Translator API。"
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Chrome Gemini Nano 网页翻译"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Chrome 内置翻译器网页翻译"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
@@ -1322,5 +1322,14 @@
     "LocalTranslatorModeChromeBuiltin": {
         "message": "Chrome 內建",
         "description": "使用支援的桌面版 Chrome 內建 Translator API。"
+    },
+    "LocalTranslatorModeGeminiNano": {
+        "message": "Chrome Gemini Nano"
+    },
+    "GeminiNanoPageTranslate": {
+        "message": "Chrome Gemini Nano 網頁翻譯"
+    },
+    "ChromeBuiltinPageTranslate": {
+        "message": "Chrome 內建翻譯器網頁翻譯"
     }
 }

--- a/packages/translators/src/translators/local.ts
+++ b/packages/translators/src/translators/local.ts
@@ -2,7 +2,7 @@ import { TranslationResult } from "../types";
 import { LRUCache } from "../utils/lru";
 import { fnv1a32 } from "../utils/hash";
 
-export type LocalTranslatorMode = "endpoint" | "chromeBuiltin";
+export type LocalTranslatorMode = "endpoint" | "chromeBuiltin" | "geminiNano";
 
 export type LocalTranslatorConfig = {
     enabled?: boolean;
@@ -82,9 +82,12 @@ const CHROME_TRANSLATOR_LANGUAGE_MAP: Record<string, string> = {
 };
 
 const SUPPORTED_LANGUAGE_CODES = new Set(Object.keys(LANGUAGE_NAMES));
-const CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES = new Set(Object.keys(CHROME_TRANSLATOR_LANGUAGE_MAP));
+const CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES = new Set(
+    Object.keys(CHROME_TRANSLATOR_LANGUAGE_MAP)
+);
 const DEFAULT_TIMEOUT_MS = 60000;
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 2;
+const GEMINI_NANO_MAX_INPUT_CHARS = 4000;
 
 class RequestLimiter {
     private active = 0;
@@ -114,7 +117,8 @@ function normalizeEndpoint(endpoint?: string) {
 }
 
 function normalizeMode(mode?: LocalTranslatorMode): LocalTranslatorMode {
-    return mode === "chromeBuiltin" ? "chromeBuiltin" : "endpoint";
+    if (mode === "chromeBuiltin" || mode === "geminiNano") return mode;
+    return "endpoint";
 }
 
 function toLanguageName(language: string) {
@@ -161,7 +165,9 @@ class LocalTranslator {
 
     supportedLanguages() {
         if (!this.enabled) return new Set<string>();
-        if (this.mode === "chromeBuiltin") return new Set(CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES);
+        if (this.mode === "chromeBuiltin" || this.mode === "geminiNano") {
+            return new Set(CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES);
+        }
         if (!this.endpoint) return new Set<string>();
         return new Set(SUPPORTED_LANGUAGE_CODES);
     }
@@ -198,7 +204,8 @@ class LocalTranslator {
         const existing = this.inflight.get(key);
         if (existing) return existing;
 
-        const request = localRequestLimiter.run(() => this.requestTranslation(text, from, to))
+        const request = localRequestLimiter
+            .run(() => this.requestTranslation(text, from, to))
             .then((result) => {
                 this.cache.set(key, result);
                 return result;
@@ -213,7 +220,67 @@ class LocalTranslator {
         if (this.mode === "chromeBuiltin") {
             return this.requestChromeBuiltinTranslation(text, from, to);
         }
+        if (this.mode === "geminiNano") return this.requestGeminiNanoTranslation(text, from, to);
         return this.requestEndpointTranslation(text, from, to);
+    }
+
+    private async requestGeminiNanoTranslation(text: string, from: string, to: string) {
+        try {
+            const languageModelApi = (globalThis as any).LanguageModel;
+            if (!languageModelApi || typeof languageModelApi.create !== "function") {
+                throw new Error("Chrome Gemini Nano Prompt API is not available in this browser.");
+            }
+            if (typeof languageModelApi.availability === "function") {
+                const availability = await languageModelApi.availability();
+                if (availability === "unavailable") {
+                    throw new Error("Chrome Gemini Nano model is unavailable on this device.");
+                }
+            }
+            const sourceLanguage = toLanguageName(from);
+            const targetLanguage = toLanguageName(to);
+            const session = await languageModelApi.create({
+                initialPrompts: [
+                    {
+                        role: "system",
+                        content: [
+                            "You are a precise translation engine.",
+                            "Translate user-provided text only.",
+                            "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
+                            "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
+                            `Source language: ${sourceLanguage}.`,
+                            `Target language: ${targetLanguage}.`,
+                        ].join("\n"),
+                    },
+                ],
+            });
+            const prompt = [
+                `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
+                "Return only the translated text.",
+                "<text>",
+                text.slice(0, GEMINI_NANO_MAX_INPUT_CHARS),
+                "</text>",
+            ].join("\n");
+            const translated = String((await session.prompt(prompt)) || "")
+                .trim()
+                .replace(/^```(?:text)?\s*/i, "")
+                .replace(/```$/i, "")
+                .replace(/^Translation:\s*/i, "")
+                .trim();
+            if (!translated) throw new Error("Chrome Gemini Nano returned an empty translation.");
+            return {
+                originalText: text,
+                mainMeaning: translated,
+                sourceLanguage: from,
+                targetLanguage: to,
+            } as TranslationResult;
+        } catch (error: any) {
+            throw {
+                errorType: "API_ERR",
+                errorCode: "CHROME_GEMINI_NANO_TRANSLATOR_ERROR",
+                errorMsg: error?.message || "Chrome Gemini Nano translation request failed.",
+                errorAct: { api: "local", mode: "geminiNano", action: "translate", text, from, to },
+            };
+        }
     }
 
     private async requestChromeBuiltinTranslation(text: string, from: string, to: string) {
@@ -224,14 +291,20 @@ class LocalTranslator {
             }
 
             const targetLanguage = toChromeTranslatorLanguage(to);
-            const sourceLanguage = from === "auto"
-                ? await this.detectChromeBuiltinLanguage(text, targetLanguage)
-                : toChromeTranslatorLanguage(from);
+            const sourceLanguage =
+                from === "auto"
+                    ? await this.detectChromeBuiltinLanguage(text, targetLanguage)
+                    : toChromeTranslatorLanguage(from);
 
             if (typeof translatorApi.availability === "function") {
-                const availability = await translatorApi.availability({ sourceLanguage, targetLanguage });
+                const availability = await translatorApi.availability({
+                    sourceLanguage,
+                    targetLanguage,
+                });
                 if (availability === "unavailable") {
-                    throw new Error(`Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`);
+                    throw new Error(
+                        `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+                    );
                 }
             }
 
@@ -252,7 +325,14 @@ class LocalTranslator {
                 errorType: "API_ERR",
                 errorCode: "CHROME_BUILTIN_TRANSLATOR_ERROR",
                 errorMsg: error?.message || "Chrome built-in Translator API request failed.",
-                errorAct: { api: "local", mode: "chromeBuiltin", action: "translate", text, from, to },
+                errorAct: {
+                    api: "local",
+                    mode: "chromeBuiltin",
+                    action: "translate",
+                    text,
+                    from,
+                    to,
+                },
             };
         }
     }
@@ -260,7 +340,9 @@ class LocalTranslator {
     private async detectChromeBuiltinLanguage(text: string, targetLanguage: string) {
         const detectorApi = (globalThis as any).LanguageDetector;
         if (!detectorApi || typeof detectorApi.create !== "function") {
-            throw new Error("Chrome built-in Translator API requires an explicit source language when Language Detector API is unavailable.");
+            throw new Error(
+                "Chrome built-in Translator API requires an explicit source language when Language Detector API is unavailable."
+            );
         }
 
         const detector = await detectorApi.create();
@@ -268,7 +350,9 @@ class LocalTranslator {
         const detected = Array.isArray(detections) ? detections[0]?.detectedLanguage : undefined;
         const sourceLanguage = toChromeTranslatorLanguage(detected || "");
         if (!sourceLanguage || sourceLanguage === targetLanguage) {
-            throw new Error("Chrome built-in Language Detector API could not determine a translatable source language.");
+            throw new Error(
+                "Chrome built-in Language Detector API could not determine a translatable source language."
+            );
         }
         return sourceLanguage;
     }
@@ -297,7 +381,9 @@ class LocalTranslator {
 
             const payload = await response.json().catch(() => ({}));
             if (!response.ok || payload?.success === false) {
-                throw new Error(payload?.error || `Local translator failed with ${response.status}`);
+                throw new Error(
+                    payload?.error || `Local translator failed with ${response.status}`
+                );
             }
 
             const translated = parseTranslatedText(payload);

--- a/packages/translators/test/local.test.ts
+++ b/packages/translators/test/local.test.ts
@@ -4,10 +4,12 @@ describe("LocalTranslator", () => {
     const originalFetch = global.fetch;
 
     const originalTranslator = (globalThis as any).Translator;
+    const originalLanguageModel = (globalThis as any).LanguageModel;
 
     afterEach(() => {
         global.fetch = originalFetch;
         (globalThis as any).Translator = originalTranslator;
+        (globalThis as any).LanguageModel = originalLanguageModel;
         jest.restoreAllMocks();
     });
 
@@ -59,7 +61,10 @@ describe("LocalTranslator", () => {
         });
         global.fetch = fetchMock as any;
 
-        const translator = new LocalTranslator({ enabled: true, endpoint: "http://local.test/translate" });
+        const translator = new LocalTranslator({
+            enabled: true,
+            endpoint: "http://local.test/translate",
+        });
         const [first, second] = await Promise.all([
             translator.translate("hello", "auto", "ko"),
             translator.translate("hello", "auto", "ko"),
@@ -87,7 +92,10 @@ describe("LocalTranslator", () => {
         const translator = new LocalTranslator({ enabled: true, mode: "chromeBuiltin" });
         const result = await translator.translate("hello", "en", "ko");
 
-        expect(availabilityMock).toHaveBeenCalledWith({ sourceLanguage: "en", targetLanguage: "ko" });
+        expect(availabilityMock).toHaveBeenCalledWith({
+            sourceLanguage: "en",
+            targetLanguage: "ko",
+        });
         expect(createMock).toHaveBeenCalledWith({ sourceLanguage: "en", targetLanguage: "ko" });
         expect(translateMock).toHaveBeenCalledWith("hello");
         expect(result).toMatchObject({
@@ -102,5 +110,32 @@ describe("LocalTranslator", () => {
         const translator = new LocalTranslator({ enabled: true, mode: "chromeBuiltin" });
         expect(translator.supportedLanguages().has("ko")).toBe(true);
         expect(translator.supportedLanguages().has("en")).toBe(true);
+    });
+
+    test("translates with Chrome Gemini Nano mode", async () => {
+        const promptMock = jest.fn().mockResolvedValue("안녕");
+        const createMock = jest.fn().mockResolvedValue({ prompt: promptMock });
+        const availabilityMock = jest.fn().mockResolvedValue("available");
+        (globalThis as any).LanguageModel = {
+            availability: availabilityMock,
+            create: createMock,
+        };
+
+        const translator = new LocalTranslator({ enabled: true, mode: "geminiNano" });
+        const result = await translator.translate("hello", "en", "ko");
+
+        expect(availabilityMock).toHaveBeenCalled();
+        expect(createMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                initialPrompts: expect.any(Array),
+            })
+        );
+        expect(promptMock).toHaveBeenCalledWith(expect.stringContaining("hello"));
+        expect(result).toMatchObject({
+            originalText: "hello",
+            mainMeaning: "안녕",
+            sourceLanguage: "en",
+            targetLanguage: "ko",
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Add Chrome Gemini Nano Prompt API as a local on-device translation mode
- Route HybridTranslate LocalTranslate through the active tab so Gemini Nano runs in a content/window context
- Add Gemini Nano page translation using the existing DOM page translation path with queueing and caching
- Keep the older Chrome built-in Translator API path as a fallback/legacy option

## Test Plan
- npm test -w @edge_translate/translators -- --runInBand
- npm test -w edge_translate -- --runInBand
- npm run build:chrome
- npm run pack:chrome -w edge_translate
- npm run pack:firefox -w edge_translate
- npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox

Note: Firefox lint reports 0 errors and the existing bundled/pdf.js warnings.