### PR TITLE
fix: run on-device AI translation in page context

### DIFF
--- a/packages/EdgeTranslate/src/common/scripts/channel.js
+++ b/packages/EdgeTranslate/src/common/scripts/channel.js
@@ -47,8 +47,14 @@ class Channel {
                         if (!server) break;
 
                         // We can call the callback only when we really provide the requested service.
-                        server(parsed.params, sender).then(
-                            (result) => callback && callback(result)
+                        Promise.resolve(server(parsed.params, sender)).then(
+                            (result) => callback && callback(result),
+                            (error) =>
+                                callback &&
+                                callback({
+                                    __edgeTranslateError: true,
+                                    message: error && error.message ? error.message : String(error),
+                                })
                         );
                         return true;
                     }
@@ -85,6 +91,8 @@ class Channel {
             chrome.runtime.sendMessage(message, (result) => {
                 if (chrome.runtime.lastError) {
                     reject(chrome.runtime.lastError);
+                } else if (result && result.__edgeTranslateError) {
+                    reject(new Error(result.message || "Extension service request failed."));
                 } else {
                     resolve(result);
                 }
@@ -190,6 +198,10 @@ class Channel {
                 chrome.tabs.sendMessage(tabId, message, (result) => {
                     if (chrome.runtime.lastError) {
                         reject(chrome.runtime.lastError);
+                    } else if (result && result.__edgeTranslateError) {
+                        reject(
+                            new Error(result.message || "Extension tab service request failed.")
+                        );
                     } else {
                         resolve(result);
                     }

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -29,6 +29,10 @@ class BannerController {
         this._domTranslationCache = new Map();
         this._domActiveTranslations = 0;
         this._domMaxConcurrentTranslations = 2;
+        this._domOnDeviceUnavailable = false;
+        this._onDeviceBridgePromise = null;
+        this._onDeviceBridgeRequestId = 0;
+        this._onDeviceBridgePending = new Map();
 
         this.addListeners();
     }
@@ -70,13 +74,13 @@ class BannerController {
             }
         });
 
-        // Provide Chrome on-device translation APIs from a window/content-script context.
+        // Provide Chrome on-device translation APIs from the page main world when possible.
         this.channel.provide("chrome_builtin_translate", async (params) => {
             const text = params && params.text ? params.text : "";
             const from = (params && params.sl) || (params && params.from) || "auto";
             const to = (params && params.tl) || (params && params.to) || "en";
             const engine = (params && params.engine) || "geminiNano";
-            return translateWithChromeOnDevice(text, from, to, engine);
+            return this.translateWithOnDeviceEngine(text, from, to, engine);
         });
 
         // Kick off DOM fallback/on-device page translation on explicit request
@@ -86,6 +90,7 @@ class BannerController {
                 sl: detail.sl || "auto",
                 tl: detail.tl || "en",
             };
+            this._domOnDeviceUnavailable = false;
             this.startDomFallback();
             // initial scan to cover existing content
             const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -101,6 +106,101 @@ class BannerController {
                 // nothing needed here yet (fallback scheduling is background-side), keep hook for future use
             }
         });
+
+        window.addEventListener("message", this.handleOnDeviceBridgeResponse.bind(this));
+    }
+
+    async ensureOnDeviceBridge() {
+        if (this._onDeviceBridgePromise) return this._onDeviceBridgePromise;
+
+        this._onDeviceBridgePromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                window.removeEventListener("message", readyHandler);
+                reject(new Error("Chrome on-device translation bridge did not become ready."));
+            }, 3000);
+
+            const readyHandler = (event) => {
+                if (event.source !== window || !event.data) return;
+                if (event.data.type !== "edge_translate_on_device_bridge_ready") return;
+                clearTimeout(timeout);
+                window.removeEventListener("message", readyHandler);
+                resolve();
+            };
+
+            window.addEventListener("message", readyHandler);
+
+            const existing = document.getElementById("edge-translate-on-device-bridge");
+            if (existing) {
+                clearTimeout(timeout);
+                window.removeEventListener("message", readyHandler);
+                resolve();
+                return;
+            }
+
+            const script = document.createElement("script");
+            script.id = "edge-translate-on-device-bridge";
+            script.src = chrome.runtime.getURL("chrome_builtin/on_device_bridge.js");
+            script.async = false;
+            script.onerror = () => {
+                clearTimeout(timeout);
+                window.removeEventListener("message", readyHandler);
+                reject(new Error("Failed to inject Chrome on-device translation bridge."));
+            };
+            (document.documentElement || document.head || document.body).appendChild(script);
+        });
+
+        return this._onDeviceBridgePromise;
+    }
+
+    requestOnDeviceBridge(detail) {
+        return new Promise((resolve, reject) => {
+            const requestId = `et-${Date.now()}-${++this._onDeviceBridgeRequestId}`;
+            const timeout = setTimeout(() => {
+                this._onDeviceBridgePending.delete(requestId);
+                reject(new Error("Chrome on-device translation bridge request timed out."));
+            }, 30000);
+
+            this._onDeviceBridgePending.set(requestId, { resolve, reject, timeout });
+            window.postMessage(
+                {
+                    type: "edge_translate_on_device_request",
+                    requestId,
+                    detail,
+                },
+                "*"
+            );
+        });
+    }
+
+    handleOnDeviceBridgeResponse(event) {
+        if (event.source !== window || !event.data) return;
+        if (event.data.type !== "edge_translate_on_device_response") return;
+
+        const pending = this._onDeviceBridgePending.get(event.data.requestId);
+        if (!pending) return;
+        this._onDeviceBridgePending.delete(event.data.requestId);
+        clearTimeout(pending.timeout);
+
+        if (event.data.error) {
+            pending.reject(
+                new Error(event.data.error.message || "Chrome on-device translation failed.")
+            );
+        } else {
+            pending.resolve(event.data.result);
+        }
+    }
+
+    async translateWithOnDeviceEngine(text, from, to, engine) {
+        try {
+            await this.ensureOnDeviceBridge();
+            return await this.requestOnDeviceBridge({ text, sl: from, tl: to, engine });
+        } catch (bridgeError) {
+            try {
+                return await translateWithChromeOnDevice(text, from, to, engine);
+            } catch (contentError) {
+                throw bridgeError || contentError;
+            }
+        }
     }
 
     /**
@@ -306,6 +406,7 @@ class BannerController {
         if (!items.length) return;
 
         if (!["chromeBuiltin", "geminiNano"].includes(this._domPageTranslateOptions.engine)) return;
+        if (this._domOnDeviceUnavailable) return;
         items.forEach((item) => this.enqueueChromeBuiltinNodeTranslation(item));
     }
 
@@ -317,7 +418,7 @@ class BannerController {
                 const cacheKey = `${sl}|${tl}|${item.text}`;
                 let translated = this._domTranslationCache.get(cacheKey);
                 if (!translated) {
-                    const result = await translateWithChromeOnDevice(
+                    const result = await this.translateWithOnDeviceEngine(
                         item.text,
                         sl,
                         tl,
@@ -332,6 +433,10 @@ class BannerController {
             } catch (error) {
                 item.parent.removeAttribute("data-et-translated");
                 this._translatedSet.delete(item.parent);
+                if (this.isOnDeviceUnavailableError(error)) {
+                    this._domOnDeviceUnavailable = true;
+                    if (this._domTranslationQueue) this._domTranslationQueue.length = 0;
+                }
             } finally {
                 this._domActiveTranslations -= 1;
                 this.flushDomTranslationQueue();
@@ -352,6 +457,11 @@ class BannerController {
             const next = this._domTranslationQueue.shift();
             next();
         }
+    }
+
+    isOnDeviceUnavailableError(error) {
+        const message = error && error.message ? error.message : String(error || "");
+        return /not available|unavailable|did not become ready|Failed to inject/i.test(message);
     }
 }
 

--- a/packages/EdgeTranslate/static/chrome_builtin/on_device_bridge.js
+++ b/packages/EdgeTranslate/static/chrome_builtin/on_device_bridge.js
@@ -1,0 +1,241 @@
+(() => {
+    if (window.__edgeTranslateOnDeviceBridgeInitialized) return;
+    window.__edgeTranslateOnDeviceBridgeInitialized = true;
+
+    const CHROME_TRANSLATOR_LANGUAGE_MAP = {
+        auto: "auto",
+        en: "en",
+        ko: "ko",
+        ja: "ja",
+        "zh-CN": "zh",
+        "zh-TW": "zh-Hant",
+        zh: "zh",
+        fr: "fr",
+        de: "de",
+        es: "es",
+        it: "it",
+        pt: "pt",
+        ru: "ru",
+        vi: "vi",
+        th: "th",
+        id: "id",
+        ar: "ar",
+        hi: "hi",
+        tr: "tr",
+        nl: "nl",
+        pl: "pl",
+        uk: "uk",
+        he: "iw",
+        iw: "iw",
+    };
+
+    const LANGUAGE_NAMES = {
+        auto: "auto-detected language",
+        en: "English",
+        ko: "Korean",
+        ja: "Japanese",
+        "zh-CN": "Simplified Chinese",
+        "zh-TW": "Traditional Chinese",
+        zh: "Chinese",
+        fr: "French",
+        de: "German",
+        es: "Spanish",
+        it: "Italian",
+        pt: "Portuguese",
+        ru: "Russian",
+        vi: "Vietnamese",
+        th: "Thai",
+        id: "Indonesian",
+        ar: "Arabic",
+        hi: "Hindi",
+        tr: "Turkish",
+        nl: "Dutch",
+        pl: "Polish",
+        uk: "Ukrainian",
+    };
+
+    const sessionCache = new Map();
+    const maxInputChars = 4000;
+
+    function toChromeTranslatorLanguage(language) {
+        return CHROME_TRANSLATOR_LANGUAGE_MAP[language] || language;
+    }
+
+    function toLanguageName(language) {
+        return LANGUAGE_NAMES[language] || language || "auto-detected language";
+    }
+
+    function normalizeGeminiNanoOutput(output) {
+        return String(output || "")
+            .trim()
+            .replace(/^```(?:text)?\s*/i, "")
+            .replace(/```$/i, "")
+            .replace(/^Translation:\s*/i, "")
+            .trim();
+    }
+
+    async function detectChromeBuiltinLanguage(text, targetLanguage) {
+        const detectorApi = window.LanguageDetector;
+        if (!detectorApi || typeof detectorApi.create !== "function") {
+            throw new Error(
+                "Chrome built-in Translator API requires an explicit source language when Language Detector API is unavailable."
+            );
+        }
+
+        const detector = await detectorApi.create();
+        const detections = await detector.detect(text);
+        const detected = Array.isArray(detections) ? detections[0]?.detectedLanguage : undefined;
+        const sourceLanguage = toChromeTranslatorLanguage(detected || "");
+        if (!sourceLanguage || sourceLanguage === targetLanguage) {
+            throw new Error(
+                "Chrome built-in Language Detector API could not determine a translatable source language."
+            );
+        }
+        return sourceLanguage;
+    }
+
+    async function translateWithChromeBuiltin(text, from, to) {
+        const translatorApi = window.Translator;
+        if (!translatorApi || typeof translatorApi.create !== "function") {
+            throw new Error(
+                "Chrome built-in Translator API is not available in this page context."
+            );
+        }
+
+        const targetLanguage = toChromeTranslatorLanguage(to);
+        const sourceLanguage =
+            from === "auto"
+                ? await detectChromeBuiltinLanguage(text, targetLanguage)
+                : toChromeTranslatorLanguage(from);
+
+        if (typeof translatorApi.availability === "function") {
+            const availability = await translatorApi.availability({
+                sourceLanguage,
+                targetLanguage,
+            });
+            if (availability === "unavailable") {
+                throw new Error(
+                    `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+                );
+            }
+        }
+
+        const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+        const translated = await translator.translate(text);
+        if (!translated)
+            throw new Error("Chrome built-in Translator API returned an empty translation.");
+        return {
+            originalText: text,
+            mainMeaning: translated,
+            translatedText: translated,
+            sourceLanguage,
+            targetLanguage,
+        };
+    }
+
+    async function getGeminiNanoSession(from, to) {
+        const languageModelApi = window.LanguageModel;
+        if (!languageModelApi || typeof languageModelApi.create !== "function") {
+            throw new Error("Chrome Gemini Nano Prompt API is not available in this page context.");
+        }
+
+        if (typeof languageModelApi.availability === "function") {
+            const availability = await languageModelApi.availability();
+            if (availability === "unavailable") {
+                throw new Error("Chrome Gemini Nano model is unavailable on this device.");
+            }
+        }
+
+        const sourceLanguage = toLanguageName(from);
+        const targetLanguage = toLanguageName(to);
+        const key = `${sourceLanguage}|${targetLanguage}`;
+        if (sessionCache.has(key)) return sessionCache.get(key);
+
+        const session = await languageModelApi.create({
+            initialPrompts: [
+                {
+                    role: "system",
+                    content: [
+                        "You are a precise translation engine.",
+                        "Translate user-provided text only.",
+                        "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
+                        "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
+                        `Source language: ${sourceLanguage}.`,
+                        `Target language: ${targetLanguage}.`,
+                    ].join("\n"),
+                },
+            ],
+        });
+        sessionCache.set(key, session);
+        return session;
+    }
+
+    async function translateWithGeminiNano(text, from, to) {
+        const session = await getGeminiNanoSession(from, to);
+        const sourceLanguage = toLanguageName(from);
+        const targetLanguage = toLanguageName(to);
+        const prompt = [
+            `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
+            "Return only the translated text.",
+            "<text>",
+            String(text).slice(0, maxInputChars),
+            "</text>",
+        ].join("\n");
+        const translated = normalizeGeminiNanoOutput(await session.prompt(prompt));
+        if (!translated) throw new Error("Chrome Gemini Nano returned an empty translation.");
+        return {
+            originalText: text,
+            mainMeaning: translated,
+            translatedText: translated,
+            sourceLanguage: from,
+            targetLanguage: to,
+        };
+    }
+
+    async function translate(detail) {
+        const text = detail && detail.text ? String(detail.text) : "";
+        const from = (detail && (detail.sl || detail.from)) || "auto";
+        const to = (detail && (detail.tl || detail.to)) || "en";
+        const engine = (detail && detail.engine) || "geminiNano";
+        if (!text.trim()) {
+            return {
+                originalText: text,
+                mainMeaning: "",
+                sourceLanguage: from,
+                targetLanguage: to,
+            };
+        }
+        if (engine === "chromeBuiltin") return translateWithChromeBuiltin(text, from, to);
+        return translateWithGeminiNano(text, from, to);
+    }
+
+    window.addEventListener("message", async (event) => {
+        if (event.source !== window || !event.data) return;
+        if (event.data.type !== "edge_translate_on_device_request") return;
+        const requestId = event.data.requestId;
+        try {
+            const result = await translate(event.data.detail || {});
+            window.postMessage(
+                {
+                    type: "edge_translate_on_device_response",
+                    requestId,
+                    result,
+                },
+                "*"
+            );
+        } catch (error) {
+            window.postMessage(
+                {
+                    type: "edge_translate_on_device_response",
+                    requestId,
+                    error: {
+                        message: error && error.message ? error.message : String(error),
+                    },
+                },
+                "*"
+            );
+        }
+    });
+
+    window.postMessage({ type: "edge_translate_on_device_bridge_ready" }, "*");
+})();


### PR DESCRIPTION
## Summary
- Inject a page main-world bridge for Chrome on-device AI APIs so Gemini Nano/Translator can be called when content-script isolated world does not expose `LanguageModel`.
- Route content translation requests through the bridge first, with content-context fallback.
- Catch rejected channel service promises and propagate them as request errors instead of causing uncaught promise errors.
- Stop DOM page translation retry loops when the on-device API is unavailable.

## Repro
Reported on:
https://www.xda-developers.com/pla-warps-winter-people-say-doesnt-why/

Error:
```text
Chrome Gemini Nano Prompt API is not available in this browser context.
```

## Test Plan
- `npm test -w edge_translate -- --runInBand`
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox`
- Verified `chrome_builtin/on_device_bridge.js` is included in Chrome zip and Firefox xpi.
