### PR TITLE
fix: inject on-device bridge with scripting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.2.1",
+            "version": "3.2.2",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/background/library/translate.js
+++ b/packages/EdgeTranslate/src/background/library/translate.js
@@ -250,6 +250,13 @@ class TranslatorManager {
             }
         });
 
+        // Inject the on-device AI bridge into the page main world from the extension
+        // service worker. This avoids page CSP/network failures caused by DOM <script src>
+        // injection on stricter sites.
+        this.channel.provide("inject_on_device_bridge", async (params, sender) =>
+            this.injectOnDeviceBridge(sender)
+        );
+
         // Pronounce service.
         this.channel.provide("pronounce", (params) => {
             let speed = params.speed;
@@ -416,6 +423,32 @@ class TranslatorManager {
             return Promise.resolve(sender.tab.id);
         }
         return this.getCurrentTabId();
+    }
+
+    async injectOnDeviceBridge(sender) {
+        const tabId = sender && sender.tab && sender.tab.id;
+        if (typeof tabId !== "number") {
+            throw new Error("Cannot inject Chrome on-device bridge without a sender tab.");
+        }
+        if (
+            typeof chrome === "undefined" ||
+            !chrome.scripting ||
+            typeof chrome.scripting.executeScript !== "function"
+        ) {
+            throw new Error("Chrome scripting API is unavailable for on-device bridge injection.");
+        }
+
+        const target = { tabId };
+        if (typeof sender.frameId === "number") target.frameIds = [sender.frameId];
+
+        await chrome.scripting.executeScript({
+            target,
+            files: ["chrome_builtin/on_device_bridge.js"],
+            world: "MAIN",
+            injectImmediately: true,
+        });
+
+        return { injected: true };
     }
 
     /**

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -113,7 +113,22 @@ class BannerController {
     async ensureOnDeviceBridge() {
         if (this._onDeviceBridgePromise) return this._onDeviceBridgePromise;
 
-        this._onDeviceBridgePromise = new Promise((resolve, reject) => {
+        this._onDeviceBridgePromise = this.injectOnDeviceBridgeViaBackground().catch(() =>
+            this.injectOnDeviceBridgeViaScriptTag()
+        );
+
+        return this._onDeviceBridgePromise;
+    }
+
+    async injectOnDeviceBridgeViaBackground() {
+        if (!this.channel || typeof this.channel.request !== "function") {
+            throw new Error("Extension background bridge injector is unavailable.");
+        }
+        await this.channel.request("inject_on_device_bridge");
+    }
+
+    injectOnDeviceBridgeViaScriptTag() {
+        return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
                 window.removeEventListener("message", readyHandler);
                 reject(new Error("Chrome on-device translation bridge did not become ready."));
@@ -130,12 +145,7 @@ class BannerController {
             window.addEventListener("message", readyHandler);
 
             const existing = document.getElementById("edge-translate-on-device-bridge");
-            if (existing) {
-                clearTimeout(timeout);
-                window.removeEventListener("message", readyHandler);
-                resolve();
-                return;
-            }
+            if (existing) existing.remove();
 
             const script = document.createElement("script");
             script.id = "edge-translate-on-device-bridge";
@@ -148,8 +158,6 @@ class BannerController {
             };
             (document.documentElement || document.head || document.body).appendChild(script);
         });
-
-        return this._onDeviceBridgePromise;
     }
 
     requestOnDeviceBridge(detail) {

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/EdgeTranslate/test/unit/background/translateManager.test.js
+++ b/packages/EdgeTranslate/test/unit/background/translateManager.test.js
@@ -5,9 +5,7 @@ describe("TranslatorManager fast tab resolution", () => {
         const manager = Object.create(TranslatorManager.prototype);
         manager.getCurrentTabId = jest.fn(async () => 99);
 
-        await expect(
-            manager.resolveTargetTabId({ tab: { id: 42 } })
-        ).resolves.toBe(42);
+        await expect(manager.resolveTargetTabId({ tab: { id: 42 } })).resolves.toBe(42);
         expect(manager.getCurrentTabId).not.toHaveBeenCalled();
     });
 
@@ -17,5 +15,40 @@ describe("TranslatorManager fast tab resolution", () => {
 
         await expect(manager.resolveTargetTabId({})).resolves.toBe(99);
         expect(manager.getCurrentTabId).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("TranslatorManager on-device bridge injection", () => {
+    const originalChrome = global.chrome;
+
+    afterEach(() => {
+        global.chrome = originalChrome;
+        jest.restoreAllMocks();
+    });
+
+    test("injects the bridge into the sender frame main world", async () => {
+        const executeScript = jest.fn().mockResolvedValue([{ result: undefined }]);
+        global.chrome = { scripting: { executeScript } };
+        const manager = Object.create(TranslatorManager.prototype);
+
+        await expect(
+            manager.injectOnDeviceBridge({ tab: { id: 42 }, frameId: 7 })
+        ).resolves.toEqual({ injected: true });
+
+        expect(executeScript).toHaveBeenCalledWith({
+            target: { tabId: 42, frameIds: [7] },
+            files: ["chrome_builtin/on_device_bridge.js"],
+            world: "MAIN",
+            injectImmediately: true,
+        });
+    });
+
+    test("rejects bridge injection without a sender tab", async () => {
+        global.chrome = { scripting: { executeScript: jest.fn() } };
+        const manager = Object.create(TranslatorManager.prototype);
+
+        await expect(manager.injectOnDeviceBridge({})).rejects.toThrow(
+            "Cannot inject Chrome on-device bridge without a sender tab."
+        );
     });
 });


### PR DESCRIPTION
## Summary
- Inject the Chrome on-device AI bridge via `chrome.scripting.executeScript({ world: "MAIN" })` from the background service worker.
- Keep the DOM `<script src="chrome-extension://...">` path only as a fallback.
- Avoid page CSP/resource-loading failures that show up as network errors when using Gemini Nano translation.
- Add unit coverage for sender-frame main-world bridge injection.
- Bump extension version to 3.2.2 for the hotfix release.

## Verification
- `npm test -w edge_translate -- --runInBand`
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox` (errors 0, existing warnings 21)
- Verified packaged Chrome/Firefox manifests are version 3.2.2 and include `chrome_builtin/on_device_bridge.js`.
