### PR TITLE
refactor: remove Gemini Nano translation mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.2.2",
+            "version": "3.3.0",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/background/library/pageTranslate.js
+++ b/packages/EdgeTranslate/src/background/library/pageTranslate.js
@@ -10,7 +10,10 @@ import { DEFAULT_SETTINGS, getOrSetDefaultSettings } from "common/scripts/settin
 function translatePage(channel) {
     getOrSetDefaultSettings(["DefaultPageTranslator", "languageSetting"], DEFAULT_SETTINGS).then(
         (result) => {
-            const translator = result.DefaultPageTranslator;
+            const translator =
+                result.DefaultPageTranslator === "GeminiNanoPageTranslate"
+                    ? "ChromeBuiltinPageTranslate"
+                    : result.DefaultPageTranslator;
             const targetLang = (result.languageSetting && result.languageSetting.tl) || "en";
             const sourceLang = (result.languageSetting && result.languageSetting.sl) || "auto";
 
@@ -20,13 +23,6 @@ function translatePage(channel) {
             switch (translator) {
                 case "GooglePageTranslate":
                     executeGoogleScript(channel);
-                    break;
-                case "GeminiNanoPageTranslate":
-                    executeDomPageTranslate(channel, {
-                        engine: "geminiNano",
-                        sl: sourceLang,
-                        tl: targetLang,
-                    });
                     break;
                 case "ChromeBuiltinPageTranslate":
                     executeDomPageTranslate(channel, {

--- a/packages/EdgeTranslate/src/background/library/translate.js
+++ b/packages/EdgeTranslate/src/background/library/translate.js
@@ -2,10 +2,7 @@ import { HybridTranslator } from "@edge_translate/translators";
 // common.log는 현재 파일에서 직접 사용하지 않습니다.
 import { promiseTabs, delayPromise } from "common/scripts/promise.js";
 import { DEFAULT_SETTINGS, getOrSetDefaultSettings } from "common/scripts/settings.js";
-import {
-    getChromeTranslatorSupportedLanguages,
-    getGeminiNanoSupportedLanguages,
-} from "common/scripts/chrome_builtin_translate.js";
+import { getChromeTranslatorSupportedLanguages } from "common/scripts/chrome_builtin_translate.js";
 import TtlCache from "./ttlCache.js";
 import { executeGoogleScript } from "./pageTranslate.js";
 
@@ -96,19 +93,23 @@ class TranslatorManager {
                 config = nextConfig || {};
                 endpointTranslator.useConfig(nextConfig);
             },
+            getMode() {
+                return config.mode === "chromeBuiltin" || config.mode === "geminiNano"
+                    ? "chromeBuiltin"
+                    : "endpoint";
+            },
             supportedLanguages() {
                 if (!config.enabled) return new Set();
-                if (config.mode === "geminiNano") return getGeminiNanoSupportedLanguages();
-                if (config.mode === "chromeBuiltin") return getChromeTranslatorSupportedLanguages();
+                if (this.getMode() === "chromeBuiltin")
+                    return getChromeTranslatorSupportedLanguages();
                 return endpointTranslator.supportedLanguages();
             },
             detect(text) {
-                if (["chromeBuiltin", "geminiNano"].includes(config.mode))
-                    return Promise.resolve("auto");
+                if (this.getMode() === "chromeBuiltin") return Promise.resolve("auto");
                 return endpointTranslator.detect(text);
             },
             async translate(text, from, to) {
-                if (!["chromeBuiltin", "geminiNano"].includes(config.mode)) {
+                if (this.getMode() !== "chromeBuiltin") {
                     return endpointTranslator.translate(text, from, to);
                 }
                 const tabId = await manager.getChromeBuiltinTargetTabId();
@@ -119,7 +120,7 @@ class TranslatorManager {
                         text,
                         sl: from,
                         tl: to,
-                        engine: config.mode,
+                        engine: "chromeBuiltin",
                     }
                 );
                 return {

--- a/packages/EdgeTranslate/src/common/scripts/chrome_builtin_translate.js
+++ b/packages/EdgeTranslate/src/common/scripts/chrome_builtin_translate.js
@@ -45,48 +45,28 @@ const CHROME_TRANSLATOR_LANGUAGE_MAP = {
     te: "te",
 };
 
-const LANGUAGE_NAMES = {
-    auto: "auto-detected language",
-    en: "English",
-    ko: "Korean",
-    ja: "Japanese",
-    "zh-CN": "Simplified Chinese",
-    "zh-TW": "Traditional Chinese",
-    zh: "Chinese",
-    fr: "French",
-    de: "German",
-    es: "Spanish",
-    it: "Italian",
-    pt: "Portuguese",
-    ru: "Russian",
-    vi: "Vietnamese",
-    th: "Thai",
-    id: "Indonesian",
-    ar: "Arabic",
-    hi: "Hindi",
-    tr: "Turkish",
-    nl: "Dutch",
-    pl: "Polish",
-    uk: "Ukrainian",
-};
-
-const GEMINI_NANO_SESSION_CACHE = new Map();
-const GEMINI_NANO_MAX_INPUT_CHARS = 4000;
+const CHROME_TRANSLATOR_CACHE = new Map();
 
 function toChromeTranslatorLanguage(language) {
-    return CHROME_TRANSLATOR_LANGUAGE_MAP[language] || language;
+    if (!language) return language;
+    const raw = String(language).trim();
+    if (!raw) return raw;
+    if (CHROME_TRANSLATOR_LANGUAGE_MAP[raw]) return CHROME_TRANSLATOR_LANGUAGE_MAP[raw];
+
+    const normalized = raw.replace(/_/g, "-");
+    const lower = normalized.toLowerCase();
+    if (lower === "auto") return "auto";
+    if (/^zh(-|$)/.test(lower)) {
+        if (/tw|hk|mo|hant/.test(lower)) return "zh-Hant";
+        return "zh";
+    }
+
+    const base = lower.split("-")[0];
+    return CHROME_TRANSLATOR_LANGUAGE_MAP[base] || base || raw;
 }
 
 function getChromeTranslatorSupportedLanguages() {
     return new Set(Object.keys(CHROME_TRANSLATOR_LANGUAGE_MAP));
-}
-
-function getGeminiNanoSupportedLanguages() {
-    return new Set(Object.keys(LANGUAGE_NAMES));
-}
-
-function toLanguageName(language) {
-    return LANGUAGE_NAMES[language] || language || "auto-detected language";
 }
 
 function isChromeBuiltinTranslatorAvailable() {
@@ -94,14 +74,6 @@ function isChromeBuiltinTranslatorAvailable() {
         typeof globalThis !== "undefined" &&
         globalThis.Translator &&
         typeof globalThis.Translator.create === "function"
-    );
-}
-
-function isGeminiNanoLanguageModelAvailable() {
-    return (
-        typeof globalThis !== "undefined" &&
-        globalThis.LanguageModel &&
-        typeof globalThis.LanguageModel.create === "function"
     );
 }
 
@@ -125,11 +97,31 @@ async function detectChromeBuiltinLanguage(text, targetLanguage) {
     return sourceLanguage;
 }
 
+async function getChromeBuiltinTranslator(sourceLanguage, targetLanguage) {
+    const key = `${sourceLanguage}|${targetLanguage}`;
+    if (CHROME_TRANSLATOR_CACHE.has(key)) return CHROME_TRANSLATOR_CACHE.get(key);
+
+    const translatorApi = globalThis.Translator;
+    if (typeof translatorApi.availability === "function") {
+        const availability = await translatorApi.availability({ sourceLanguage, targetLanguage });
+        if (availability === "unavailable") {
+            throw new Error(
+                `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+            );
+        }
+    }
+
+    const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+    CHROME_TRANSLATOR_CACHE.set(key, translator);
+    return translator;
+}
+
 async function translateWithChromeBuiltin(text, from, to) {
     if (!text || !String(text).trim()) {
         return {
             originalText: text || "",
             mainMeaning: "",
+            translatedText: "",
             sourceLanguage: from,
             targetLanguage: to,
         };
@@ -146,16 +138,7 @@ async function translateWithChromeBuiltin(text, from, to) {
             ? await detectChromeBuiltinLanguage(text, targetLanguage)
             : toChromeTranslatorLanguage(from);
 
-    if (typeof translatorApi.availability === "function") {
-        const availability = await translatorApi.availability({ sourceLanguage, targetLanguage });
-        if (availability === "unavailable") {
-            throw new Error(
-                `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
-            );
-        }
-    }
-
-    const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+    const translator = await getChromeBuiltinTranslator(sourceLanguage, targetLanguage);
     const translated = await translator.translate(text);
     if (!translated) {
         throw new Error("Chrome built-in Translator API returned an empty translation.");
@@ -170,100 +153,14 @@ async function translateWithChromeBuiltin(text, from, to) {
     };
 }
 
-function normalizeGeminiNanoOutput(output) {
-    return String(output || "")
-        .trim()
-        .replace(/^```(?:text)?\s*/i, "")
-        .replace(/```$/i, "")
-        .replace(/^Translation:\s*/i, "")
-        .trim();
-}
-
-async function getGeminiNanoSession(from, to) {
-    const languageModelApi = globalThis.LanguageModel;
-    if (!languageModelApi || typeof languageModelApi.create !== "function") {
-        throw new Error("Chrome Gemini Nano Prompt API is not available in this browser context.");
-    }
-
-    const sourceLanguage = toLanguageName(from);
-    const targetLanguage = toLanguageName(to);
-    const key = `${sourceLanguage}|${targetLanguage}`;
-    if (GEMINI_NANO_SESSION_CACHE.has(key)) return GEMINI_NANO_SESSION_CACHE.get(key);
-
-    if (typeof languageModelApi.availability === "function") {
-        const availability = await languageModelApi.availability();
-        if (availability === "unavailable") {
-            throw new Error("Chrome Gemini Nano model is unavailable on this device.");
-        }
-    }
-
-    const session = await languageModelApi.create({
-        initialPrompts: [
-            {
-                role: "system",
-                content: [
-                    "You are a precise translation engine.",
-                    "Translate user-provided text only.",
-                    "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
-                    "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
-                    `Source language: ${sourceLanguage}.`,
-                    `Target language: ${targetLanguage}.`,
-                ].join("\n"),
-            },
-        ],
-    });
-    GEMINI_NANO_SESSION_CACHE.set(key, session);
-    return session;
-}
-
-async function translateWithGeminiNano(text, from, to) {
-    if (!text || !String(text).trim()) {
-        return {
-            originalText: text || "",
-            mainMeaning: "",
-            sourceLanguage: from,
-            targetLanguage: to,
-        };
-    }
-
-    const session = await getGeminiNanoSession(from, to);
-    const safeText = String(text).slice(0, GEMINI_NANO_MAX_INPUT_CHARS);
-    const sourceLanguage = toLanguageName(from);
-    const targetLanguage = toLanguageName(to);
-    const prompt = [
-        `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
-        "Return only the translated text.",
-        "<text>",
-        safeText,
-        "</text>",
-    ].join("\n");
-    const output = await session.prompt(prompt);
-    const translated = normalizeGeminiNanoOutput(output);
-    if (!translated) {
-        throw new Error("Chrome Gemini Nano returned an empty translation.");
-    }
-
-    return {
-        originalText: text,
-        mainMeaning: translated,
-        translatedText: translated,
-        sourceLanguage: from,
-        targetLanguage: to,
-    };
-}
-
-async function translateWithChromeOnDevice(text, from, to, engine = "geminiNano") {
-    if (engine === "chromeBuiltin") return translateWithChromeBuiltin(text, from, to);
-    return translateWithGeminiNano(text, from, to);
+async function translateWithChromeOnDevice(text, from, to) {
+    return translateWithChromeBuiltin(text, from, to);
 }
 
 export {
     getChromeTranslatorSupportedLanguages,
-    getGeminiNanoSupportedLanguages,
     isChromeBuiltinTranslatorAvailable,
-    isGeminiNanoLanguageModelAvailable,
     toChromeTranslatorLanguage,
     translateWithChromeBuiltin,
     translateWithChromeOnDevice,
-    translateWithGeminiNano,
 };

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -1,6 +1,9 @@
 import Channel from "common/scripts/channel.js";
 import { DEFAULT_SETTINGS, getOrSetDefaultSettings } from "common/scripts/settings.js";
-import { translateWithChromeOnDevice } from "common/scripts/chrome_builtin_translate.js";
+import {
+    toChromeTranslatorLanguage,
+    translateWithChromeOnDevice,
+} from "common/scripts/chrome_builtin_translate.js";
 
 /**
  * Control the visibility of page translator banners.
@@ -26,6 +29,7 @@ class BannerController {
         this._scheduleBatch = null;
         this._pendingNodes = new Set();
         this._domPageTranslateOptions = { engine: "dom", sl: "auto", tl: "en" };
+        this._domResolvedSourceLanguage = null;
         this._domTranslationCache = new Map();
         this._domActiveTranslations = 0;
         this._domMaxConcurrentTranslations = 2;
@@ -79,18 +83,20 @@ class BannerController {
             const text = params && params.text ? params.text : "";
             const from = (params && params.sl) || (params && params.from) || "auto";
             const to = (params && params.tl) || (params && params.to) || "en";
-            const engine = (params && params.engine) || "geminiNano";
-            return this.translateWithOnDeviceEngine(text, from, to, engine);
+            return this.translateWithOnDeviceEngine(text, from, to);
         });
 
         // Kick off DOM fallback/on-device page translation on explicit request
         this.channel.on("start_dom_page_translate", (detail = {}) => {
             this._domPageTranslateOptions = {
-                engine: detail.engine || "dom",
+                engine: detail.engine === "dom" ? "dom" : "chromeBuiltin",
                 sl: detail.sl || "auto",
                 tl: detail.tl || "en",
             };
             this._domOnDeviceUnavailable = false;
+            this._domResolvedSourceLanguage = this.resolveDomPageSourceLanguage(
+                this._domPageTranslateOptions.sl
+            );
             this.startDomFallback();
             // initial scan to cover existing content
             const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -198,13 +204,18 @@ class BannerController {
         }
     }
 
-    async translateWithOnDeviceEngine(text, from, to, engine) {
+    async translateWithOnDeviceEngine(text, from, to) {
         try {
             await this.ensureOnDeviceBridge();
-            return await this.requestOnDeviceBridge({ text, sl: from, tl: to, engine });
+            return await this.requestOnDeviceBridge({
+                text,
+                sl: from,
+                tl: to,
+                engine: "chromeBuiltin",
+            });
         } catch (bridgeError) {
             try {
-                return await translateWithChromeOnDevice(text, from, to, engine);
+                return await translateWithChromeOnDevice(text, from, to);
             } catch (contentError) {
                 throw bridgeError || contentError;
             }
@@ -343,6 +354,23 @@ class BannerController {
         });
     }
 
+    resolveDomPageSourceLanguage(configuredSourceLanguage) {
+        if (configuredSourceLanguage && configuredSourceLanguage !== "auto") {
+            return toChromeTranslatorLanguage(configuredSourceLanguage);
+        }
+
+        const pageLanguage =
+            document.documentElement?.getAttribute("lang") ||
+            document.body?.getAttribute("lang") ||
+            document
+                .querySelector("meta[http-equiv='content-language']")
+                ?.getAttribute("content") ||
+            "";
+        const normalized = toChromeTranslatorLanguage(pageLanguage);
+        if (normalized && normalized !== "auto") return normalized;
+        return configuredSourceLanguage || "auto";
+    }
+
     /**
      * Start DOM fallback translation observer with aggressive filtering.
      */
@@ -356,7 +384,7 @@ class BannerController {
             if (!p) return false;
             const tn = p.tagName;
             if (/^(SCRIPT|STYLE|NOSCRIPT|TEXTAREA|INPUT|SELECT|OPTION)$/i.test(tn)) return false;
-            if (p.hasAttribute("data-et-translated")) return false;
+            if (this._translatedSet.has(node)) return false;
             return true;
         };
         const enqueue = (node) => {
@@ -404,16 +432,15 @@ class BannerController {
         const items = [];
         for (const n of nodes) {
             const p = n.parentElement;
-            if (!p || this._translatedSet.has(p)) continue;
+            if (!p || this._translatedSet.has(n)) continue;
             const text = String(n.nodeValue || "").trim();
             if (text.length < 2) continue;
             items.push({ node: n, parent: p, text });
-            this._translatedSet.add(p);
-            p.setAttribute("data-et-translated", "1");
+            this._translatedSet.add(n);
         }
         if (!items.length) return;
 
-        if (!["chromeBuiltin", "geminiNano"].includes(this._domPageTranslateOptions.engine)) return;
+        if (this._domPageTranslateOptions.engine !== "chromeBuiltin") return;
         if (this._domOnDeviceUnavailable) return;
         items.forEach((item) => this.enqueueChromeBuiltinNodeTranslation(item));
     }
@@ -422,16 +449,12 @@ class BannerController {
         const run = async () => {
             this._domActiveTranslations += 1;
             try {
-                const { sl, tl } = this._domPageTranslateOptions;
-                const cacheKey = `${sl}|${tl}|${item.text}`;
+                const { tl } = this._domPageTranslateOptions;
+                const sl = this._domResolvedSourceLanguage || this._domPageTranslateOptions.sl;
+                const cacheKey = `${this._domPageTranslateOptions.engine}|${sl}|${tl}|${item.text}`;
                 let translated = this._domTranslationCache.get(cacheKey);
                 if (!translated) {
-                    const result = await this.translateWithOnDeviceEngine(
-                        item.text,
-                        sl,
-                        tl,
-                        this._domPageTranslateOptions.engine
-                    );
+                    const result = await this.translateWithOnDeviceEngine(item.text, sl, tl);
                     translated = result.mainMeaning || result.translatedText;
                     if (translated) this._domTranslationCache.set(cacheKey, translated);
                 }
@@ -439,8 +462,7 @@ class BannerController {
                     item.node.nodeValue = translated;
                 }
             } catch (error) {
-                item.parent.removeAttribute("data-et-translated");
-                this._translatedSet.delete(item.parent);
+                this._translatedSet.delete(item.node);
                 if (this.isOnDeviceUnavailableError(error)) {
                     this._domOnDeviceUnavailable = true;
                     if (this._domTranslationQueue) this._domTranslationQueue.length = 0;
@@ -469,7 +491,9 @@ class BannerController {
 
     isOnDeviceUnavailableError(error) {
         const message = error && error.message ? error.message : String(error || "");
-        return /not available|unavailable|did not become ready|Failed to inject/i.test(message);
+        return /network|not available|unavailable|did not become ready|Failed to inject|timed out/i.test(
+            message
+        );
     }
 }
 

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.2.2",
+    "version": "3.3.0",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/EdgeTranslate/src/options/options.html
+++ b/packages/EdgeTranslate/src/options/options.html
@@ -189,11 +189,6 @@
                                     data-i18n-name="LocalTranslatorModeEndpoint"
                                 ></option>
                                 <option
-                                    value="geminiNano"
-                                    class="i18n"
-                                    data-i18n-name="LocalTranslatorModeGeminiNano"
-                                ></option>
-                                <option
                                     value="chromeBuiltin"
                                     class="i18n"
                                     data-i18n-name="LocalTranslatorModeChromeBuiltin"
@@ -321,18 +316,18 @@
                     </div>
                     <div class="column">
                         <label
-                            for="gemini-nano-page-translator"
+                            for="chrome-builtin-page-translator"
                             class="checked-label i18n"
-                            data-i18n-name="GeminiNanoPageTranslate"
+                            data-i18n-name="ChromeBuiltinPageTranslate"
                         >
                             <input
                                 type="radio"
-                                value="GeminiNanoPageTranslate"
+                                value="ChromeBuiltinPageTranslate"
                                 setting-type="radio"
                                 setting-path="DefaultPageTranslator"
                                 class="radio"
                                 name="default-page-translator"
-                                id="gemini-nano-page-translator"
+                                id="chrome-builtin-page-translator"
                             />
                         </label>
                     </div>

--- a/packages/EdgeTranslate/src/options/options.js
+++ b/packages/EdgeTranslate/src/options/options.js
@@ -55,6 +55,20 @@ window.onload = () => {
         for (let element of [...inputElements]) {
             let settingItemPath = element.getAttribute("setting-path").split(/\s/g);
             let settingItemValue = getSetting(result, settingItemPath);
+            if (
+                settingItemPath.join(" ") === "LocalTranslatorConfig mode" &&
+                settingItemValue === "geminiNano"
+            ) {
+                settingItemValue = "chromeBuiltin";
+                saveOption(result, settingItemPath, settingItemValue);
+            }
+            if (
+                settingItemPath.join(" ") === "DefaultPageTranslator" &&
+                settingItemValue === "GeminiNanoPageTranslate"
+            ) {
+                settingItemValue = "ChromeBuiltinPageTranslate";
+                saveOption(result, settingItemPath, settingItemValue);
+            }
 
             switch (element.getAttribute("setting-type")) {
                 case "checkbox":

--- a/packages/EdgeTranslate/static/_locales/en/messages.json
+++ b/packages/EdgeTranslate/static/_locales/en/messages.json
@@ -1323,12 +1323,6 @@
         "message": "Chrome Built-in",
         "description": "Use Chrome desktop built-in Translator API when available."
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Chrome Gemini Nano Page Translate"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome Built-in Translator Page Translate"
     }

--- a/packages/EdgeTranslate/static/_locales/ja/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ja/messages.json
@@ -1323,12 +1323,6 @@
         "message": "Chrome 内蔵",
         "description": "対応するデスクトップ版 Chrome の内蔵 Translator API を使用します。"
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Chrome Gemini Nano ページ翻訳"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 組み込み翻訳ページ翻訳"
     }

--- a/packages/EdgeTranslate/static/_locales/ko/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ko/messages.json
@@ -483,12 +483,6 @@
         "message": "Chrome 내장",
         "description": "지원되는 데스크톱 Chrome의 내장 Translator API를 사용합니다."
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Chrome Gemini Nano 페이지 번역"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 내장 번역기 페이지 번역"
     }

--- a/packages/EdgeTranslate/static/_locales/ru/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ru/messages.json
@@ -1323,12 +1323,6 @@
         "message": "Chrome Built-in",
         "description": "Использовать встроенный Translator API настольного Chrome, если доступен."
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Перевод страницы Chrome Gemini Nano"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Перевод страницы встроенным переводчиком Chrome"
     }

--- a/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
@@ -1323,12 +1323,6 @@
         "message": "Chrome 内置",
         "description": "使用支持的桌面版 Chrome 内置 Translator API。"
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Chrome Gemini Nano 网页翻译"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 内置翻译器网页翻译"
     }

--- a/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
@@ -1323,12 +1323,6 @@
         "message": "Chrome 內建",
         "description": "使用支援的桌面版 Chrome 內建 Translator API。"
     },
-    "LocalTranslatorModeGeminiNano": {
-        "message": "Chrome Gemini Nano"
-    },
-    "GeminiNanoPageTranslate": {
-        "message": "Chrome Gemini Nano 網頁翻譯"
-    },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 內建翻譯器網頁翻譯"
     }

--- a/packages/EdgeTranslate/static/chrome_builtin/on_device_bridge.js
+++ b/packages/EdgeTranslate/static/chrome_builtin/on_device_bridge.js
@@ -29,49 +29,24 @@
         iw: "iw",
     };
 
-    const LANGUAGE_NAMES = {
-        auto: "auto-detected language",
-        en: "English",
-        ko: "Korean",
-        ja: "Japanese",
-        "zh-CN": "Simplified Chinese",
-        "zh-TW": "Traditional Chinese",
-        zh: "Chinese",
-        fr: "French",
-        de: "German",
-        es: "Spanish",
-        it: "Italian",
-        pt: "Portuguese",
-        ru: "Russian",
-        vi: "Vietnamese",
-        th: "Thai",
-        id: "Indonesian",
-        ar: "Arabic",
-        hi: "Hindi",
-        tr: "Turkish",
-        nl: "Dutch",
-        pl: "Polish",
-        uk: "Ukrainian",
-    };
-
-    const sessionCache = new Map();
-    const maxInputChars = 4000;
+    const translatorCache = new Map();
 
     function toChromeTranslatorLanguage(language) {
-        return CHROME_TRANSLATOR_LANGUAGE_MAP[language] || language;
-    }
+        if (!language) return language;
+        const raw = String(language).trim();
+        if (!raw) return raw;
+        if (CHROME_TRANSLATOR_LANGUAGE_MAP[raw]) return CHROME_TRANSLATOR_LANGUAGE_MAP[raw];
 
-    function toLanguageName(language) {
-        return LANGUAGE_NAMES[language] || language || "auto-detected language";
-    }
+        const normalized = raw.replace(/_/g, "-");
+        const lower = normalized.toLowerCase();
+        if (lower === "auto") return "auto";
+        if (/^zh(-|$)/.test(lower)) {
+            if (/tw|hk|mo|hant/.test(lower)) return "zh-Hant";
+            return "zh";
+        }
 
-    function normalizeGeminiNanoOutput(output) {
-        return String(output || "")
-            .trim()
-            .replace(/^```(?:text)?\s*/i, "")
-            .replace(/```$/i, "")
-            .replace(/^Translation:\s*/i, "")
-            .trim();
+        const base = lower.split("-")[0];
+        return CHROME_TRANSLATOR_LANGUAGE_MAP[base] || base || raw;
     }
 
     async function detectChromeBuiltinLanguage(text, targetLanguage) {
@@ -94,6 +69,28 @@
         return sourceLanguage;
     }
 
+    async function getChromeBuiltinTranslator(sourceLanguage, targetLanguage) {
+        const key = `${sourceLanguage}|${targetLanguage}`;
+        if (translatorCache.has(key)) return translatorCache.get(key);
+
+        const translatorApi = window.Translator;
+        if (typeof translatorApi.availability === "function") {
+            const availability = await translatorApi.availability({
+                sourceLanguage,
+                targetLanguage,
+            });
+            if (availability === "unavailable") {
+                throw new Error(
+                    `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+                );
+            }
+        }
+
+        const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+        translatorCache.set(key, translator);
+        return translator;
+    }
+
     async function translateWithChromeBuiltin(text, from, to) {
         const translatorApi = window.Translator;
         if (!translatorApi || typeof translatorApi.create !== "function") {
@@ -108,19 +105,7 @@
                 ? await detectChromeBuiltinLanguage(text, targetLanguage)
                 : toChromeTranslatorLanguage(from);
 
-        if (typeof translatorApi.availability === "function") {
-            const availability = await translatorApi.availability({
-                sourceLanguage,
-                targetLanguage,
-            });
-            if (availability === "unavailable") {
-                throw new Error(
-                    `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
-                );
-            }
-        }
-
-        const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+        const translator = await getChromeBuiltinTranslator(sourceLanguage, targetLanguage);
         const translated = await translator.translate(text);
         if (!translated)
             throw new Error("Chrome built-in Translator API returned an empty translation.");
@@ -133,80 +118,20 @@
         };
     }
 
-    async function getGeminiNanoSession(from, to) {
-        const languageModelApi = window.LanguageModel;
-        if (!languageModelApi || typeof languageModelApi.create !== "function") {
-            throw new Error("Chrome Gemini Nano Prompt API is not available in this page context.");
-        }
-
-        if (typeof languageModelApi.availability === "function") {
-            const availability = await languageModelApi.availability();
-            if (availability === "unavailable") {
-                throw new Error("Chrome Gemini Nano model is unavailable on this device.");
-            }
-        }
-
-        const sourceLanguage = toLanguageName(from);
-        const targetLanguage = toLanguageName(to);
-        const key = `${sourceLanguage}|${targetLanguage}`;
-        if (sessionCache.has(key)) return sessionCache.get(key);
-
-        const session = await languageModelApi.create({
-            initialPrompts: [
-                {
-                    role: "system",
-                    content: [
-                        "You are a precise translation engine.",
-                        "Translate user-provided text only.",
-                        "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
-                        "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
-                        `Source language: ${sourceLanguage}.`,
-                        `Target language: ${targetLanguage}.`,
-                    ].join("\n"),
-                },
-            ],
-        });
-        sessionCache.set(key, session);
-        return session;
-    }
-
-    async function translateWithGeminiNano(text, from, to) {
-        const session = await getGeminiNanoSession(from, to);
-        const sourceLanguage = toLanguageName(from);
-        const targetLanguage = toLanguageName(to);
-        const prompt = [
-            `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
-            "Return only the translated text.",
-            "<text>",
-            String(text).slice(0, maxInputChars),
-            "</text>",
-        ].join("\n");
-        const translated = normalizeGeminiNanoOutput(await session.prompt(prompt));
-        if (!translated) throw new Error("Chrome Gemini Nano returned an empty translation.");
-        return {
-            originalText: text,
-            mainMeaning: translated,
-            translatedText: translated,
-            sourceLanguage: from,
-            targetLanguage: to,
-        };
-    }
-
     async function translate(detail) {
         const text = detail && detail.text ? String(detail.text) : "";
         const from = (detail && (detail.sl || detail.from)) || "auto";
         const to = (detail && (detail.tl || detail.to)) || "en";
-        const engine = (detail && detail.engine) || "geminiNano";
         if (!text.trim()) {
             return {
                 originalText: text,
                 mainMeaning: "",
+                translatedText: "",
                 sourceLanguage: from,
                 targetLanguage: to,
             };
         }
-        if (engine === "chromeBuiltin") return translateWithChromeBuiltin(text, from, to);
-        return translateWithGeminiNano(text, from, to);
+        return translateWithChromeBuiltin(text, from, to);
     }
 
     window.addEventListener("message", async (event) => {

--- a/packages/EdgeTranslate/test/unit/common/chromeBuiltinTranslate.test.js
+++ b/packages/EdgeTranslate/test/unit/common/chromeBuiltinTranslate.test.js
@@ -1,0 +1,46 @@
+import {
+    toChromeTranslatorLanguage,
+    translateWithChromeOnDevice,
+} from "../../../src/common/scripts/chrome_builtin_translate.js";
+
+describe("Chrome built-in translator helper", () => {
+    const originalTranslator = globalThis.Translator;
+    const originalLanguageDetector = globalThis.LanguageDetector;
+
+    afterEach(() => {
+        globalThis.Translator = originalTranslator;
+        globalThis.LanguageDetector = originalLanguageDetector;
+        jest.restoreAllMocks();
+    });
+
+    it("normalizes regional language codes for Chrome Translator", () => {
+        expect(toChromeTranslatorLanguage("en-US")).toBe("en");
+        expect(toChromeTranslatorLanguage("ko_KR")).toBe("ko");
+        expect(toChromeTranslatorLanguage("zh-TW")).toBe("zh-Hant");
+        expect(toChromeTranslatorLanguage("zh-Hans-CN")).toBe("zh");
+        expect(toChromeTranslatorLanguage("he-IL")).toBe("iw");
+    });
+
+    it("uses Chrome Translator API and reuses translators", async () => {
+        const translateMock = jest.fn().mockResolvedValueOnce("안녕").mockResolvedValueOnce("세계");
+        const createMock = jest.fn().mockResolvedValue({ translate: translateMock });
+        globalThis.Translator = {
+            availability: jest.fn().mockResolvedValue("available"),
+            create: createMock,
+        };
+        const first = await translateWithChromeOnDevice("hello", "en-US", "ko-KR");
+        const second = await translateWithChromeOnDevice("world", "en-US", "ko-KR");
+
+        expect(globalThis.Translator.availability).toHaveBeenCalledTimes(1);
+        expect(globalThis.Translator.availability).toHaveBeenCalledWith({
+            sourceLanguage: "en",
+            targetLanguage: "ko",
+        });
+        expect(createMock).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledWith({ sourceLanguage: "en", targetLanguage: "ko" });
+        expect(translateMock).toHaveBeenNthCalledWith(1, "hello");
+        expect(translateMock).toHaveBeenNthCalledWith(2, "world");
+        expect(first.mainMeaning).toBe("안녕");
+        expect(second.mainMeaning).toBe("세계");
+    });
+});

--- a/packages/translators/src/translators/local.ts
+++ b/packages/translators/src/translators/local.ts
@@ -2,11 +2,11 @@ import { TranslationResult } from "../types";
 import { LRUCache } from "../utils/lru";
 import { fnv1a32 } from "../utils/hash";
 
-export type LocalTranslatorMode = "endpoint" | "chromeBuiltin" | "geminiNano";
+export type LocalTranslatorMode = "endpoint" | "chromeBuiltin";
 
 export type LocalTranslatorConfig = {
     enabled?: boolean;
-    mode?: LocalTranslatorMode;
+    mode?: LocalTranslatorMode | string;
     endpoint?: string;
     apiKey?: string;
     timeoutMs?: number;
@@ -87,7 +87,6 @@ const CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES = new Set(
 );
 const DEFAULT_TIMEOUT_MS = 60000;
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 2;
-const GEMINI_NANO_MAX_INPUT_CHARS = 4000;
 
 class RequestLimiter {
     private active = 0;
@@ -116,8 +115,8 @@ function normalizeEndpoint(endpoint?: string) {
     return (endpoint || "").trim();
 }
 
-function normalizeMode(mode?: LocalTranslatorMode): LocalTranslatorMode {
-    if (mode === "chromeBuiltin" || mode === "geminiNano") return mode;
+function normalizeMode(mode?: string): LocalTranslatorMode {
+    if (mode === "chromeBuiltin" || mode === "geminiNano") return "chromeBuiltin";
     return "endpoint";
 }
 
@@ -126,7 +125,21 @@ function toLanguageName(language: string) {
 }
 
 function toChromeTranslatorLanguage(language: string) {
-    return CHROME_TRANSLATOR_LANGUAGE_MAP[language] || language;
+    if (!language) return language;
+    const raw = String(language).trim();
+    if (!raw) return raw;
+    if (CHROME_TRANSLATOR_LANGUAGE_MAP[raw]) return CHROME_TRANSLATOR_LANGUAGE_MAP[raw];
+
+    const normalized = raw.replace(/_/g, "-");
+    const lower = normalized.toLowerCase();
+    if (lower === "auto") return "auto";
+    if (/^zh(-|$)/.test(lower)) {
+        if (/tw|hk|mo|hant/.test(lower)) return "zh-Hant";
+        return "zh";
+    }
+
+    const base = lower.split("-")[0];
+    return CHROME_TRANSLATOR_LANGUAGE_MAP[base] || base || raw;
 }
 
 function parseTranslatedText(payload: any) {
@@ -148,6 +161,7 @@ class LocalTranslator {
     private timeoutMs = DEFAULT_TIMEOUT_MS;
     private cache = new LRUCache<string, TranslationResult>({ max: 200, ttl: 10 * 60 * 1000 });
     private inflight = new Map<string, Promise<TranslationResult>>();
+    private chromeTranslatorCache = new Map<string, any>();
 
     constructor(config: LocalTranslatorConfig = {}) {
         this.useConfig(config);
@@ -161,11 +175,12 @@ class LocalTranslator {
         this.timeoutMs = config.timeoutMs || DEFAULT_TIMEOUT_MS;
         this.cache.clear();
         this.inflight.clear();
+        this.chromeTranslatorCache.clear();
     }
 
     supportedLanguages() {
         if (!this.enabled) return new Set<string>();
-        if (this.mode === "chromeBuiltin" || this.mode === "geminiNano") {
+        if (this.mode === "chromeBuiltin") {
             return new Set(CHROME_TRANSLATOR_SUPPORTED_LANGUAGE_CODES);
         }
         if (!this.endpoint) return new Set<string>();
@@ -220,67 +235,7 @@ class LocalTranslator {
         if (this.mode === "chromeBuiltin") {
             return this.requestChromeBuiltinTranslation(text, from, to);
         }
-        if (this.mode === "geminiNano") return this.requestGeminiNanoTranslation(text, from, to);
         return this.requestEndpointTranslation(text, from, to);
-    }
-
-    private async requestGeminiNanoTranslation(text: string, from: string, to: string) {
-        try {
-            const languageModelApi = (globalThis as any).LanguageModel;
-            if (!languageModelApi || typeof languageModelApi.create !== "function") {
-                throw new Error("Chrome Gemini Nano Prompt API is not available in this browser.");
-            }
-            if (typeof languageModelApi.availability === "function") {
-                const availability = await languageModelApi.availability();
-                if (availability === "unavailable") {
-                    throw new Error("Chrome Gemini Nano model is unavailable on this device.");
-                }
-            }
-            const sourceLanguage = toLanguageName(from);
-            const targetLanguage = toLanguageName(to);
-            const session = await languageModelApi.create({
-                initialPrompts: [
-                    {
-                        role: "system",
-                        content: [
-                            "You are a precise translation engine.",
-                            "Translate user-provided text only.",
-                            "Preserve meaning, tone, punctuation, line breaks, URLs, numbers, names, and HTML-like entities.",
-                            "Do not explain, summarize, romanize, add notes, or wrap the answer in quotes/code fences.",
-                            `Source language: ${sourceLanguage}.`,
-                            `Target language: ${targetLanguage}.`,
-                        ].join("\n"),
-                    },
-                ],
-            });
-            const prompt = [
-                `Translate the following text from ${sourceLanguage} to ${targetLanguage}.`,
-                "Return only the translated text.",
-                "<text>",
-                text.slice(0, GEMINI_NANO_MAX_INPUT_CHARS),
-                "</text>",
-            ].join("\n");
-            const translated = String((await session.prompt(prompt)) || "")
-                .trim()
-                .replace(/^```(?:text)?\s*/i, "")
-                .replace(/```$/i, "")
-                .replace(/^Translation:\s*/i, "")
-                .trim();
-            if (!translated) throw new Error("Chrome Gemini Nano returned an empty translation.");
-            return {
-                originalText: text,
-                mainMeaning: translated,
-                sourceLanguage: from,
-                targetLanguage: to,
-            } as TranslationResult;
-        } catch (error: any) {
-            throw {
-                errorType: "API_ERR",
-                errorCode: "CHROME_GEMINI_NANO_TRANSLATOR_ERROR",
-                errorMsg: error?.message || "Chrome Gemini Nano translation request failed.",
-                errorAct: { api: "local", mode: "geminiNano", action: "translate", text, from, to },
-            };
-        }
     }
 
     private async requestChromeBuiltinTranslation(text: string, from: string, to: string) {
@@ -296,19 +251,10 @@ class LocalTranslator {
                     ? await this.detectChromeBuiltinLanguage(text, targetLanguage)
                     : toChromeTranslatorLanguage(from);
 
-            if (typeof translatorApi.availability === "function") {
-                const availability = await translatorApi.availability({
-                    sourceLanguage,
-                    targetLanguage,
-                });
-                if (availability === "unavailable") {
-                    throw new Error(
-                        `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
-                    );
-                }
-            }
-
-            const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+            const translator = await this.getChromeBuiltinTranslator(
+                sourceLanguage,
+                targetLanguage
+            );
             const translated = await translator.translate(text);
             if (!translated) {
                 throw new Error("Chrome built-in Translator API returned an empty translation.");
@@ -335,6 +281,28 @@ class LocalTranslator {
                 },
             };
         }
+    }
+
+    private async getChromeBuiltinTranslator(sourceLanguage: string, targetLanguage: string) {
+        const key = `${sourceLanguage}|${targetLanguage}`;
+        if (this.chromeTranslatorCache.has(key)) return this.chromeTranslatorCache.get(key);
+
+        const translatorApi = (globalThis as any).Translator;
+        if (typeof translatorApi.availability === "function") {
+            const availability = await translatorApi.availability({
+                sourceLanguage,
+                targetLanguage,
+            });
+            if (availability === "unavailable") {
+                throw new Error(
+                    `Chrome built-in Translator API does not support ${sourceLanguage} to ${targetLanguage}.`
+                );
+            }
+        }
+
+        const translator = await translatorApi.create({ sourceLanguage, targetLanguage });
+        this.chromeTranslatorCache.set(key, translator);
+        return translator;
     }
 
     private async detectChromeBuiltinLanguage(text: string, targetLanguage: string) {

--- a/packages/translators/test/local.test.ts
+++ b/packages/translators/test/local.test.ts
@@ -4,12 +4,10 @@ describe("LocalTranslator", () => {
     const originalFetch = global.fetch;
 
     const originalTranslator = (globalThis as any).Translator;
-    const originalLanguageModel = (globalThis as any).LanguageModel;
 
     afterEach(() => {
         global.fetch = originalFetch;
         (globalThis as any).Translator = originalTranslator;
-        (globalThis as any).LanguageModel = originalLanguageModel;
         jest.restoreAllMocks();
     });
 
@@ -92,6 +90,7 @@ describe("LocalTranslator", () => {
         const translator = new LocalTranslator({ enabled: true, mode: "chromeBuiltin" });
         const result = await translator.translate("hello", "en", "ko");
 
+        expect(availabilityMock).toHaveBeenCalledTimes(1);
         expect(availabilityMock).toHaveBeenCalledWith({
             sourceLanguage: "en",
             targetLanguage: "ko",
@@ -106,31 +105,50 @@ describe("LocalTranslator", () => {
         });
     });
 
+    test("normalizes regional Chrome Translator language codes and reuses the translator", async () => {
+        const translateMock = jest.fn().mockResolvedValue("안녕");
+        const createMock = jest.fn().mockResolvedValue({ translate: translateMock });
+        const availabilityMock = jest.fn().mockResolvedValue("available");
+        (globalThis as any).Translator = {
+            availability: availabilityMock,
+            create: createMock,
+        };
+
+        const translator = new LocalTranslator({ enabled: true, mode: "chromeBuiltin" });
+        await translator.translate("hello", "en-US", "ko-KR");
+        await translator.translate("world", "en-US", "ko-KR");
+
+        expect(availabilityMock).toHaveBeenCalledTimes(1);
+        expect(availabilityMock).toHaveBeenCalledWith({
+            sourceLanguage: "en",
+            targetLanguage: "ko",
+        });
+        expect(createMock).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledWith({ sourceLanguage: "en", targetLanguage: "ko" });
+        expect(translateMock).toHaveBeenCalledTimes(2);
+    });
+
     test("advertises Chrome built-in support without endpoint", () => {
         const translator = new LocalTranslator({ enabled: true, mode: "chromeBuiltin" });
         expect(translator.supportedLanguages().has("ko")).toBe(true);
         expect(translator.supportedLanguages().has("en")).toBe(true);
     });
 
-    test("translates with Chrome Gemini Nano mode", async () => {
-        const promptMock = jest.fn().mockResolvedValue("안녕");
-        const createMock = jest.fn().mockResolvedValue({ prompt: promptMock });
-        const availabilityMock = jest.fn().mockResolvedValue("available");
-        (globalThis as any).LanguageModel = {
-            availability: availabilityMock,
-            create: createMock,
+    test("migrates legacy removed on-device mode to Chrome Translator API", async () => {
+        const chromeTranslateMock = jest.fn().mockResolvedValue("안녕");
+        const chromeCreateMock = jest.fn().mockResolvedValue({ translate: chromeTranslateMock });
+        (globalThis as any).Translator = {
+            availability: jest.fn().mockResolvedValue("available"),
+            create: chromeCreateMock,
         };
-
         const translator = new LocalTranslator({ enabled: true, mode: "geminiNano" });
         const result = await translator.translate("hello", "en", "ko");
 
-        expect(availabilityMock).toHaveBeenCalled();
-        expect(createMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                initialPrompts: expect.any(Array),
-            })
-        );
-        expect(promptMock).toHaveBeenCalledWith(expect.stringContaining("hello"));
+        expect(chromeCreateMock).toHaveBeenCalledWith({
+            sourceLanguage: "en",
+            targetLanguage: "ko",
+        });
+        expect(chromeTranslateMock).toHaveBeenCalledWith("hello");
         expect(result).toMatchObject({
             originalText: "hello",
             mainMeaning: "안녕",


### PR DESCRIPTION
## Summary
- Remove Gemini Nano / `LanguageModel` translation runtime from on-device translation.
- Keep legacy settings migration: stored `geminiNano` / `GeminiNanoPageTranslate` values are mapped to Chrome Built-in Translator mode.
- Improve Chrome Built-in Translator API usage:
  - normalize regional language codes such as `en-US`, `ko-KR`, `zh-TW`, `he-IL`
  - reuse `Translator` instances per language pair
  - run `Translator.availability()` only when creating a new translator
  - use page `lang` metadata to avoid repeated auto-detection during DOM page translation
  - track translated text nodes directly to avoid duplicate parent-level skipping
- Update options UI/locales to expose only Endpoint and Chrome Built-in on-device modes.
- Bump extension version to `3.3.0`.

## Test Plan
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm test -w edge_translate -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox`

## Package verification
- Chrome and Firefox archives have manifest version `3.3.0`.
- `chrome_builtin/on_device_bridge.js` is included.
- Final runtime bundles contain no `LanguageModel` / Gemini translation code.
