### PR TITLE
fix: translate DOM pages with block context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -4,6 +4,10 @@ import {
     toChromeTranslatorLanguage,
     translateWithChromeOnDevice,
 } from "common/scripts/chrome_builtin_translate.js";
+import {
+    buildContextTranslationGroups,
+    splitTranslatedContext,
+} from "./dom_page_translate_context.js";
 
 /**
  * Control the visibility of page translator banners.
@@ -426,23 +430,73 @@ class BannerController {
     }
 
     /**
-     * Translate a batch of text nodes, marking parents to avoid duplicates.
+     * Translate a batch of text nodes with block-level context first.
      */
     translateBatchNodes(nodes) {
-        const items = [];
+        const eligibleNodes = [];
         for (const n of nodes) {
             const p = n.parentElement;
             if (!p || this._translatedSet.has(n)) continue;
             const text = String(n.nodeValue || "").trim();
             if (text.length < 2) continue;
-            items.push({ node: n, parent: p, text });
+            eligibleNodes.push(n);
             this._translatedSet.add(n);
         }
-        if (!items.length) return;
+        if (!eligibleNodes.length) return;
 
         if (this._domPageTranslateOptions.engine !== "chromeBuiltin") return;
         if (this._domOnDeviceUnavailable) return;
-        items.forEach((item) => this.enqueueChromeBuiltinNodeTranslation(item));
+
+        const groups = buildContextTranslationGroups(eligibleNodes);
+        groups.forEach((group) => this.enqueueChromeBuiltinGroupTranslation(group));
+    }
+
+    enqueueChromeBuiltinGroupTranslation(group) {
+        const run = async () => {
+            this._domActiveTranslations += 1;
+            try {
+                const { tl } = this._domPageTranslateOptions;
+                const sl = this._domResolvedSourceLanguage || this._domPageTranslateOptions.sl;
+                const cacheKey = `${this._domPageTranslateOptions.engine}|context|${sl}|${tl}|${group.sourceText}`;
+                let translated = this._domTranslationCache.get(cacheKey);
+                if (!translated) {
+                    const result = await this.translateWithOnDeviceEngine(group.sourceText, sl, tl);
+                    translated = result.mainMeaning || result.translatedText;
+                    if (translated) this._domTranslationCache.set(cacheKey, translated);
+                }
+
+                const translatedParts = splitTranslatedContext(translated, group.nodes.length);
+                if (!translatedParts) {
+                    group.nodes.forEach((node, index) => {
+                        this.enqueueChromeBuiltinNodeTranslation({
+                            node,
+                            parent: node.parentElement,
+                            text: group.texts[index],
+                        });
+                    });
+                    return;
+                }
+
+                group.nodes.forEach((node, index) => {
+                    if (translatedParts[index] && node.parentElement) {
+                        node.nodeValue = translatedParts[index];
+                    }
+                });
+            } catch (error) {
+                group.nodes.forEach((node) => this._translatedSet.delete(node));
+                if (this.isOnDeviceUnavailableError(error)) {
+                    this._domOnDeviceUnavailable = true;
+                    if (this._domTranslationQueue) this._domTranslationQueue.length = 0;
+                }
+            } finally {
+                this._domActiveTranslations -= 1;
+                this.flushDomTranslationQueue();
+            }
+        };
+
+        if (!this._domTranslationQueue) this._domTranslationQueue = [];
+        this._domTranslationQueue.push(run);
+        this.flushDomTranslationQueue();
     }
 
     enqueueChromeBuiltinNodeTranslation(item) {

--- a/packages/EdgeTranslate/src/content/dom_page_translate_context.js
+++ b/packages/EdgeTranslate/src/content/dom_page_translate_context.js
@@ -1,0 +1,117 @@
+const BLOCK_TAGS = new Set([
+    "ADDRESS",
+    "ARTICLE",
+    "ASIDE",
+    "BLOCKQUOTE",
+    "CAPTION",
+    "DD",
+    "DIV",
+    "DL",
+    "DT",
+    "FIGCAPTION",
+    "FIGURE",
+    "FOOTER",
+    "FORM",
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "HEADER",
+    "LI",
+    "MAIN",
+    "NAV",
+    "OL",
+    "P",
+    "PRE",
+    "SECTION",
+    "TABLE",
+    "TBODY",
+    "TD",
+    "TFOOT",
+    "TH",
+    "THEAD",
+    "TR",
+    "UL",
+]);
+
+function normalizeTextNodeValue(node) {
+    return String((node && node.nodeValue) || "")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function getContextBlockElement(node) {
+    let element = node && node.parentElement;
+    while (element && element !== document.body && element !== document.documentElement) {
+        if (BLOCK_TAGS.has(element.tagName)) return element;
+        element = element.parentElement;
+    }
+    return node && node.parentElement;
+}
+
+function buildContextTranslationGroups(nodes, options = {}) {
+    const maxChars = options.maxChars || 3500;
+    const buckets = new Map();
+
+    for (const node of nodes || []) {
+        if (!node || node.nodeType !== Node.TEXT_NODE) continue;
+        const text = normalizeTextNodeValue(node);
+        if (!text) continue;
+        const block = getContextBlockElement(node) || node.parentElement;
+        if (!block) continue;
+        if (!buckets.has(block)) buckets.set(block, []);
+        buckets.get(block).push({ node, text });
+    }
+
+    const groups = [];
+    for (const [block, entries] of buckets.entries()) {
+        let current = [];
+        let currentLength = 0;
+        for (const entry of entries) {
+            const projectedLength = currentLength + entry.text.length + (current.length ? 1 : 0);
+            if (current.length && projectedLength > maxChars) {
+                groups.push(createContextGroup(block, current));
+                current = [];
+                currentLength = 0;
+            }
+            current.push(entry);
+            currentLength += entry.text.length + (current.length > 1 ? 1 : 0);
+        }
+        if (current.length) groups.push(createContextGroup(block, current));
+    }
+
+    return groups;
+}
+
+function createContextGroup(block, entries) {
+    return {
+        block,
+        nodes: entries.map((entry) => entry.node),
+        texts: entries.map((entry) => entry.text),
+        sourceText: entries.map((entry) => entry.text).join("\n"),
+    };
+}
+
+function splitTranslatedContext(translatedText, expectedCount) {
+    const translated = String(translatedText || "").trim();
+    if (!translated) return [];
+    if (expectedCount <= 1) return [translated];
+
+    const lines = translated
+        .split(/\r?\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+    if (lines.length === expectedCount) return lines;
+
+    const sentences = translated
+        .match(/[^.!?。！？]+[.!?。！？]?/g)
+        ?.map((part) => part.trim())
+        .filter(Boolean);
+    if (sentences && sentences.length === expectedCount) return sentences;
+
+    return null;
+}
+
+export { buildContextTranslationGroups, splitTranslatedContext };

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/EdgeTranslate/test/unit/content/domPageTranslateContext.test.js
+++ b/packages/EdgeTranslate/test/unit/content/domPageTranslateContext.test.js
@@ -1,0 +1,50 @@
+import {
+    buildContextTranslationGroups,
+    splitTranslatedContext,
+} from "../../../src/content/dom_page_translate_context.js";
+
+describe("DOM page translation context grouping", () => {
+    it("groups sibling text nodes under the same block into one context translation request", () => {
+        document.body.innerHTML = `
+            <article>
+                <p id="sample">
+                    <span>Out of the box, the Kindle is good at only one thing.</span>
+                    <span>Well, two.</span>
+                    <span>It lets me buy books from Amazon and read them with very little friction.</span>
+                    <span>That simplicity works well for most people, but I want customization and an experience that goes beyond the core functionality.</span>
+                </p>
+            </article>
+        `;
+        const nodes = Array.from(
+            document.querySelectorAll("#sample span"),
+            (span) => span.firstChild
+        );
+
+        const groups = buildContextTranslationGroups(nodes);
+
+        expect(groups).toHaveLength(1);
+        expect(groups[0].nodes).toEqual(nodes);
+        expect(groups[0].sourceText).toBe(
+            [
+                "Out of the box, the Kindle is good at only one thing.",
+                "Well, two.",
+                "It lets me buy books from Amazon and read them with very little friction.",
+                "That simplicity works well for most people, but I want customization and an experience that goes beyond the core functionality.",
+            ].join("\n")
+        );
+    });
+
+    it("splits translated context lines back to matching source text nodes", () => {
+        const translated = [
+            "기본 상태에서 Kindle은 한 가지를 잘합니다.",
+            "아니, 두 가지죠.",
+            "Amazon에서 책을 사고 거의 불편함 없이 읽게 해줍니다.",
+        ].join("\n");
+
+        expect(splitTranslatedContext(translated, 3)).toEqual([
+            "기본 상태에서 Kindle은 한 가지를 잘합니다.",
+            "아니, 두 가지죠.",
+            "Amazon에서 책을 사고 거의 불편함 없이 읽게 해줍니다.",
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Translate Chrome Built-in DOM page translation in block-level context groups instead of isolated text nodes.
- Add a pure helper to group sibling text nodes under paragraph/list/block containers and split translated context back into nodes.
- Fall back to the previous per-node translation path if Chrome Translator does not preserve line boundaries.
- Bump extension version to `3.3.1`.

## Why
Short text-node translation produced awkward output such as `Well, two.` -> `글쎄, 두.` because the Translator API saw the sentence without surrounding context. Grouping text under the same paragraph/block gives the on-device Translator API the neighboring sentences.

## Test Plan
- `npm test -w edge_translate -- --runInBand test/unit/content/domPageTranslateContext.test.js`
- `npm test -w edge_translate -- --runInBand`
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox`

## Package verification
- Chrome/Firefox archives have manifest version `3.3.1`.
- `chrome_builtin/on_device_bridge.js` is included.
- `content/banner_controller.js` bundle contains the context grouping path.
