### PR TITLE
feat: prefer readable block on-device page translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -6,6 +6,7 @@ import {
 } from "common/scripts/chrome_builtin_translate.js";
 import {
     buildContextTranslationGroups,
+    createReadableBlockReplacement,
     splitTranslatedContext,
 } from "./dom_page_translate_context.js";
 
@@ -30,6 +31,7 @@ class BannerController {
         // DOM fallback observer state
         this._mo = null;
         this._translatedSet = new WeakSet();
+        this._translatedBlocks = new WeakSet();
         this._scheduleBatch = null;
         this._pendingNodes = new Set();
         this._domPageTranslateOptions = { engine: "dom", sl: "auto", tl: "en" };
@@ -388,6 +390,11 @@ class BannerController {
             if (!p) return false;
             const tn = p.tagName;
             if (/^(SCRIPT|STYLE|NOSCRIPT|TEXTAREA|INPUT|SELECT|OPTION)$/i.test(tn)) return false;
+            let ancestor = p;
+            while (ancestor && ancestor !== document.documentElement) {
+                if (this._translatedBlocks.has(ancestor)) return false;
+                ancestor = ancestor.parentElement;
+            }
             if (this._translatedSet.has(node)) return false;
             return true;
         };
@@ -437,6 +444,16 @@ class BannerController {
         for (const n of nodes) {
             const p = n.parentElement;
             if (!p || this._translatedSet.has(n)) continue;
+            let ancestor = p;
+            let insideTranslatedBlock = false;
+            while (ancestor && ancestor !== document.documentElement) {
+                if (this._translatedBlocks.has(ancestor)) {
+                    insideTranslatedBlock = true;
+                    break;
+                }
+                ancestor = ancestor.parentElement;
+            }
+            if (insideTranslatedBlock) continue;
             const text = String(n.nodeValue || "").trim();
             if (text.length < 2) continue;
             eligibleNodes.push(n);
@@ -457,12 +474,26 @@ class BannerController {
             try {
                 const { tl } = this._domPageTranslateOptions;
                 const sl = this._domResolvedSourceLanguage || this._domPageTranslateOptions.sl;
-                const cacheKey = `${this._domPageTranslateOptions.engine}|context|${sl}|${tl}|${group.sourceText}`;
+                const readableBlockReplacement = createReadableBlockReplacement(group);
+                const sourceText = readableBlockReplacement
+                    ? readableBlockReplacement.sourceText
+                    : group.sourceText;
+                const cacheMode = readableBlockReplacement ? "readable-block" : "context";
+                const cacheKey = `${this._domPageTranslateOptions.engine}|${cacheMode}|${sl}|${tl}|${sourceText}`;
                 let translated = this._domTranslationCache.get(cacheKey);
                 if (!translated) {
-                    const result = await this.translateWithOnDeviceEngine(group.sourceText, sl, tl);
+                    const result = await this.translateWithOnDeviceEngine(sourceText, sl, tl);
                     translated = result.mainMeaning || result.translatedText;
                     if (translated) this._domTranslationCache.set(cacheKey, translated);
+                }
+
+                if (readableBlockReplacement) {
+                    const block = readableBlockReplacement.block;
+                    if (translated && block && block.isConnected) {
+                        this._translatedBlocks.add(block);
+                        block.textContent = translated;
+                    }
+                    return;
                 }
 
                 const translatedParts = splitTranslatedContext(translated, group.nodes.length);

--- a/packages/EdgeTranslate/src/content/dom_page_translate_context.js
+++ b/packages/EdgeTranslate/src/content/dom_page_translate_context.js
@@ -36,10 +36,68 @@ const BLOCK_TAGS = new Set([
     "UL",
 ]);
 
+const READABLE_REPLACE_BLOCK_TAGS = new Set([
+    "BLOCKQUOTE",
+    "CAPTION",
+    "DD",
+    "DT",
+    "FIGCAPTION",
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "LI",
+    "P",
+]);
+
+const UNSAFE_WHOLE_BLOCK_REPLACE_SELECTOR = [
+    "a",
+    "button",
+    "canvas",
+    "code",
+    "embed",
+    "iframe",
+    "img",
+    "input",
+    "kbd",
+    "math",
+    "object",
+    "option",
+    "picture",
+    "pre",
+    "samp",
+    "script",
+    "select",
+    "style",
+    "svg",
+    "textarea",
+    "video",
+    "audio",
+].join(",");
+
 function normalizeTextNodeValue(node) {
     return String((node && node.nodeValue) || "")
         .replace(/\s+/g, " ")
         .trim();
+}
+
+function normalizeBlockText(value) {
+    return String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function getMeaningfulTextNodes(element) {
+    if (!element) return [];
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+    let node;
+    while ((node = walker.nextNode())) {
+        if (normalizeTextNodeValue(node)) nodes.push(node);
+    }
+    return nodes;
 }
 
 function getContextBlockElement(node) {
@@ -94,6 +152,32 @@ function createContextGroup(block, entries) {
     };
 }
 
+function createReadableBlockReplacement(group, options = {}) {
+    const minNodes = options.minNodes || 2;
+    const maxChars = options.maxChars || 3500;
+    const block = group && group.block;
+    if (!block || !READABLE_REPLACE_BLOCK_TAGS.has(block.tagName)) return null;
+    if (!group.nodes || group.nodes.length < minNodes) return null;
+    if (block.querySelector && block.querySelector(UNSAFE_WHOLE_BLOCK_REPLACE_SELECTOR)) {
+        return null;
+    }
+
+    const meaningfulNodes = getMeaningfulTextNodes(block);
+    const groupNodes = new Set(group.nodes);
+    if (!meaningfulNodes.length || meaningfulNodes.some((node) => !groupNodes.has(node))) {
+        return null;
+    }
+
+    const sourceText = normalizeBlockText(block.textContent);
+    if (!sourceText || sourceText.length > maxChars) return null;
+
+    return {
+        block,
+        nodes: group.nodes,
+        sourceText,
+    };
+}
+
 function splitTranslatedContext(translatedText, expectedCount) {
     const translated = String(translatedText || "").trim();
     if (!translated) return [];
@@ -114,4 +198,4 @@ function splitTranslatedContext(translatedText, expectedCount) {
     return null;
 }
 
-export { buildContextTranslationGroups, splitTranslatedContext };
+export { buildContextTranslationGroups, createReadableBlockReplacement, splitTranslatedContext };

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.3.1",
+    "version": "3.3.2",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/EdgeTranslate/test/unit/content/domPageTranslateContext.test.js
+++ b/packages/EdgeTranslate/test/unit/content/domPageTranslateContext.test.js
@@ -1,5 +1,6 @@
 import {
     buildContextTranslationGroups,
+    createReadableBlockReplacement,
     splitTranslatedContext,
 } from "../../../src/content/dom_page_translate_context.js";
 
@@ -46,5 +47,43 @@ describe("DOM page translation context grouping", () => {
             "아니, 두 가지죠.",
             "Amazon에서 책을 사고 거의 불편함 없이 읽게 해줍니다.",
         ]);
+    });
+
+    it("prefers replacing simple readable paragraphs as one full-context block", () => {
+        document.body.innerHTML = `
+            <article>
+                <p id="sample">
+                    <span>Out of the box, the Kindle is good at only one thing.</span>
+                    <span>Well, two.</span>
+                    <span>It lets me buy books from Amazon and read them with very little friction.</span>
+                </p>
+            </article>
+        `;
+        const nodes = Array.from(
+            document.querySelectorAll("#sample span"),
+            (span) => span.firstChild
+        );
+        const [group] = buildContextTranslationGroups(nodes);
+
+        expect(createReadableBlockReplacement(group)).toMatchObject({
+            block: document.getElementById("sample"),
+            sourceText:
+                "Out of the box, the Kindle is good at only one thing. Well, two. It lets me buy books from Amazon and read them with very little friction.",
+        });
+    });
+
+    it("does not whole-replace blocks that contain links or controls", () => {
+        document.body.innerHTML = `
+            <p id="sample">
+                Read the <a href="https://example.test">original article</a> before translating.
+            </p>
+        `;
+        const nodes = Array.from(
+            document.querySelectorAll("#sample, #sample *"),
+            (element) => element.firstChild
+        ).filter(Boolean);
+        const [group] = buildContextTranslationGroups(nodes);
+
+        expect(createReadableBlockReplacement(group)).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- Prefer full readable-block replacement for simple on-device page-translation paragraphs/headings/lists.
- Translate safe text blocks as one normalized paragraph instead of newline-splitting and redistributing every text node.
- Keep DOM-preserving fallback for blocks with links, controls, media, code, or unsafe interactive content.
- Bump extension version to 3.3.2.

## Why
Chrome's built-in Translator API can still produce awkward Korean when short fragments such as `Well, two.` are translated independently. A full paragraph request gives the browser translator the strongest available context, even if that means sacrificing inline DOM preservation for simple text-only blocks.

## Test Plan
- `npm run format -w edge_translate`
- `npm test -w edge_translate -- --runInBand`
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox`

## Release Assets Verified Locally
- `dist-release/edge_translate_chrome_v3.3.2.zip`
- `dist-release/edge_translate_firefox_v3.3.2.xpi`
