### PR TITLE
perf: skip Bing details for long translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25336,7 +25336,7 @@
         },
         "packages/EdgeTranslate": {
             "name": "edge_translate",
-            "version": "3.3.2",
+            "version": "3.3.3",
             "dependencies": {
                 "@edge_translate/translators": "^0.1.4",
                 "dompurify": "^2.3.6",

--- a/packages/EdgeTranslate/package.json
+++ b/packages/EdgeTranslate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "edge_translate",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "private": true,
     "scripts": {
         "test": "jest",

--- a/packages/EdgeTranslate/src/manifest.json
+++ b/packages/EdgeTranslate/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_AppName__",
     "description": "__MSG_Description__",
-    "version": "3.3.2",
+    "version": "3.3.3",
     "homepage_url": "https://github.com/Meapri/EdgeTranslate-v3",
     "default_locale": "en",
     "background": {

--- a/packages/translators/src/translators/bing.ts
+++ b/packages/translators/src/translators/bing.ts
@@ -58,6 +58,14 @@ class BingTranslator {
     TTS_AUTH = { region: "", token: "" };
 
     /**
+     * Thresholds for deciding whether Bing dictionary/example details are useful.
+     * Longer selections are usually sentence/paragraph translations, where extra
+     * lookup/example requests only slow down the result without improving mainMeaning.
+     */
+    DETAIL_LOOKUP_MAX_WORDS = 3;
+    DETAIL_LOOKUP_MAX_CHARS = 60;
+
+    /**
      * Request count.
      */
     count = 0;
@@ -904,6 +912,15 @@ class BingTranslator {
         return new Set(this.LAN_TO_CODE.keys());
     }
 
+    shouldFetchDetailedTranslation(text: string) {
+        const normalized = String(text || "").replace(/\s+/g, " ").trim();
+        if (!normalized) return false;
+        if (normalized.length > this.DETAIL_LOOKUP_MAX_CHARS) return false;
+        const wordCount = normalized.split(/\s+/).filter(Boolean).length;
+        if (wordCount > this.DETAIL_LOOKUP_MAX_WORDS) return false;
+        return true;
+    }
+
     /**
      * Detect language of given text.
      *
@@ -1018,6 +1035,11 @@ class BingTranslator {
             // Add language information to translation result
             transResult.sourceLanguage = from;
             transResult.targetLanguage = to;
+
+            if (!this.shouldFetchDetailedTranslation(text)) {
+                this.cache.set(cacheKey, transResult);
+                return transResult;
+            }
             
             // Run lookup and examples in parallel for better performance
             const [lookupResponse, exampleResponse] = await Promise.allSettled([

--- a/packages/translators/test/bing.test.ts
+++ b/packages/translators/test/bing.test.ts
@@ -58,4 +58,73 @@ describe("bing translator api", () => {
             targetLanguage: "ko",
         });
     });
+
+    it("skips dictionary lookup and examples for long sentence translations", async () => {
+        const translator = new BingTranslator();
+        translator.IG = "TESTIG123";
+        translator.key = "123456";
+        translator.token = "test-token";
+        translator.IID = "translator.5028";
+        const requestedUrls: string[] = [];
+
+        jest.spyOn(translator, "request").mockImplementation(async (constructParams: any, args: string[]) => {
+            const params = constructParams.call(translator, ...args);
+            requestedUrls.push(params.url);
+            if (params.url.startsWith("ttranslatev3")) {
+                return [
+                    {
+                        detectedLanguage: { language: "en" },
+                        translations: [{ text: "Kindle은 기본적으로 한두 가지 일을 잘합니다." }],
+                    },
+                ];
+            }
+            return [];
+        });
+
+        const result = await translator.translate(
+            "Out of the box, the Kindle is good at only one thing. Well, two.",
+            "en",
+            "ko"
+        );
+
+        expect(result.mainMeaning).toBe("Kindle은 기본적으로 한두 가지 일을 잘합니다.");
+        expect(requestedUrls).toEqual([expect.stringMatching(/^ttranslatev3/)]);
+    });
+
+    it("keeps dictionary lookup and examples for short word translations", async () => {
+        const translator = new BingTranslator();
+        translator.IG = "TESTIG123";
+        translator.key = "123456";
+        translator.token = "test-token";
+        translator.IID = "translator.5028";
+        const requestedUrls: string[] = [];
+
+        jest.spyOn(translator, "request").mockImplementation(async (constructParams: any, args: string[]) => {
+            const params = constructParams.call(translator, ...args);
+            requestedUrls.push(params.url);
+            if (params.url.startsWith("ttranslatev3")) {
+                return [
+                    {
+                        detectedLanguage: { language: "en" },
+                        translations: [{ text: "마찰" }],
+                    },
+                ];
+            }
+            if (params.url.startsWith("tlookupv3") || params.url.startsWith("texamplev3")) {
+                return [];
+            }
+            throw new Error(`Unexpected Bing mock request: ${params.url}`);
+        });
+
+        const result = await translator.translate("friction", "en", "ko");
+
+        expect(result.mainMeaning).toBe("마찰");
+        expect(requestedUrls).toEqual(
+            expect.arrayContaining([
+                expect.stringMatching(/^ttranslatev3/),
+                expect.stringMatching(/^tlookupv3/),
+                expect.stringMatching(/^texamplev3/),
+            ])
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- Speeds up normal Bing sentence/paragraph translations by skipping dictionary lookup and example requests for longer selections.
- Keeps Bing's detailed lookup/example behavior for short word/phrase translations where dictionary-style results are useful.
- Adds regression tests for both fast sentence translation and detailed short-word translation.
- Bumps extension version to 3.3.3.

## Behavior
- Text over 60 characters or over 3 words returns after the main translation request.
- Short selections still fetch lookup/example details.

## Test Plan
- `npm test -w @edge_translate/translators -- --runInBand`
- `npm test -w edge_translate -- --runInBand`
- `npm run build:chrome`
- `npm run pack:chrome -w edge_translate`
- `npm run pack:firefox -w edge_translate`
- `npx --yes web-ext@8.9.0 lint -s packages/EdgeTranslate/build/firefox`

## Release Assets Verified Locally
- `dist-release/edge_translate_chrome_v3.3.3.zip`
- `dist-release/edge_translate_firefox_v3.3.3.xpi`
