### PR TITLE
feat: add local endpoint page translation

### DIFF
--- a/packages/EdgeTranslate/src/background/library/pageTranslate.js
+++ b/packages/EdgeTranslate/src/background/library/pageTranslate.js
@@ -31,6 +31,13 @@ function translatePage(channel) {
                         tl: targetLang,
                     });
                     break;
+                case "LocalPageTranslate":
+                    executeDomPageTranslate(channel, {
+                        engine: "localEndpoint",
+                        sl: sourceLang,
+                        tl: targetLang,
+                    });
+                    break;
                 case "DomPageTranslate":
                     executeDomPageTranslate(channel, {
                         engine: "dom",

--- a/packages/EdgeTranslate/src/common/scripts/settings.js
+++ b/packages/EdgeTranslate/src/common/scripts/settings.js
@@ -35,6 +35,7 @@ const DEFAULT_SETTINGS = {
         mode: "endpoint",
         endpoint: "",
         apiKey: "",
+        timeoutMs: 120000,
     },
     HybridTranslatorConfig: {
         // The translators used in current hybrid translate.

--- a/packages/EdgeTranslate/src/content/banner_controller.js
+++ b/packages/EdgeTranslate/src/content/banner_controller.js
@@ -95,7 +95,7 @@ class BannerController {
         // Kick off DOM fallback/on-device page translation on explicit request
         this.channel.on("start_dom_page_translate", (detail = {}) => {
             this._domPageTranslateOptions = {
-                engine: detail.engine === "dom" ? "dom" : "chromeBuiltin",
+                engine: this.normalizeDomPageTranslateEngine(detail.engine),
                 sl: detail.sl || "auto",
                 tl: detail.tl || "en",
             };
@@ -120,6 +120,11 @@ class BannerController {
         });
 
         window.addEventListener("message", this.handleOnDeviceBridgeResponse.bind(this));
+    }
+
+    normalizeDomPageTranslateEngine(engine) {
+        if (engine === "dom" || engine === "localEndpoint") return engine;
+        return "chromeBuiltin";
     }
 
     async ensureOnDeviceBridge() {
@@ -226,6 +231,25 @@ class BannerController {
                 throw bridgeError || contentError;
             }
         }
+    }
+
+    async translateWithDomPageEngine(text, from, to) {
+        if (this._domPageTranslateOptions.engine === "localEndpoint") {
+            return await this.channel.request("translate_text_quiet", {
+                text,
+                sl: from,
+                tl: to,
+                translatorId: "LocalTranslate",
+            });
+        }
+        return await this.translateWithOnDeviceEngine(text, from, to);
+    }
+
+    getReadableBlockReplacementOptions() {
+        if (this._domPageTranslateOptions.engine === "localEndpoint") {
+            return { maxChars: 1400 };
+        }
+        return undefined;
     }
 
     /**
@@ -461,20 +485,31 @@ class BannerController {
         }
         if (!eligibleNodes.length) return;
 
-        if (this._domPageTranslateOptions.engine !== "chromeBuiltin") return;
-        if (this._domOnDeviceUnavailable) return;
+        if (this._domPageTranslateOptions.engine === "dom") return;
+        if (
+            this._domPageTranslateOptions.engine === "chromeBuiltin" &&
+            this._domOnDeviceUnavailable
+        )
+            return;
 
-        const groups = buildContextTranslationGroups(eligibleNodes);
-        groups.forEach((group) => this.enqueueChromeBuiltinGroupTranslation(group));
+        const groupOptions =
+            this._domPageTranslateOptions.engine === "localEndpoint"
+                ? { maxChars: 1400 }
+                : undefined;
+        const groups = buildContextTranslationGroups(eligibleNodes, groupOptions);
+        groups.forEach((group) => this.enqueueDomPageGroupTranslation(group));
     }
 
-    enqueueChromeBuiltinGroupTranslation(group) {
+    enqueueDomPageGroupTranslation(group) {
         const run = async () => {
             this._domActiveTranslations += 1;
             try {
                 const { tl } = this._domPageTranslateOptions;
                 const sl = this._domResolvedSourceLanguage || this._domPageTranslateOptions.sl;
-                const readableBlockReplacement = createReadableBlockReplacement(group);
+                const readableBlockReplacement = createReadableBlockReplacement(
+                    group,
+                    this.getReadableBlockReplacementOptions()
+                );
                 const sourceText = readableBlockReplacement
                     ? readableBlockReplacement.sourceText
                     : group.sourceText;
@@ -482,7 +517,7 @@ class BannerController {
                 const cacheKey = `${this._domPageTranslateOptions.engine}|${cacheMode}|${sl}|${tl}|${sourceText}`;
                 let translated = this._domTranslationCache.get(cacheKey);
                 if (!translated) {
-                    const result = await this.translateWithOnDeviceEngine(sourceText, sl, tl);
+                    const result = await this.translateWithDomPageEngine(sourceText, sl, tl);
                     translated = result.mainMeaning || result.translatedText;
                     if (translated) this._domTranslationCache.set(cacheKey, translated);
                 }
@@ -499,7 +534,7 @@ class BannerController {
                 const translatedParts = splitTranslatedContext(translated, group.nodes.length);
                 if (!translatedParts) {
                     group.nodes.forEach((node, index) => {
-                        this.enqueueChromeBuiltinNodeTranslation({
+                        this.enqueueDomPageNodeTranslation({
                             node,
                             parent: node.parentElement,
                             text: group.texts[index],
@@ -515,7 +550,10 @@ class BannerController {
                 });
             } catch (error) {
                 group.nodes.forEach((node) => this._translatedSet.delete(node));
-                if (this.isOnDeviceUnavailableError(error)) {
+                if (
+                    this._domPageTranslateOptions.engine === "chromeBuiltin" &&
+                    this.isOnDeviceUnavailableError(error)
+                ) {
                     this._domOnDeviceUnavailable = true;
                     if (this._domTranslationQueue) this._domTranslationQueue.length = 0;
                 }
@@ -530,7 +568,7 @@ class BannerController {
         this.flushDomTranslationQueue();
     }
 
-    enqueueChromeBuiltinNodeTranslation(item) {
+    enqueueDomPageNodeTranslation(item) {
         const run = async () => {
             this._domActiveTranslations += 1;
             try {
@@ -539,7 +577,7 @@ class BannerController {
                 const cacheKey = `${this._domPageTranslateOptions.engine}|${sl}|${tl}|${item.text}`;
                 let translated = this._domTranslationCache.get(cacheKey);
                 if (!translated) {
-                    const result = await this.translateWithOnDeviceEngine(item.text, sl, tl);
+                    const result = await this.translateWithDomPageEngine(item.text, sl, tl);
                     translated = result.mainMeaning || result.translatedText;
                     if (translated) this._domTranslationCache.set(cacheKey, translated);
                 }
@@ -548,7 +586,10 @@ class BannerController {
                 }
             } catch (error) {
                 this._translatedSet.delete(item.node);
-                if (this.isOnDeviceUnavailableError(error)) {
+                if (
+                    this._domPageTranslateOptions.engine === "chromeBuiltin" &&
+                    this.isOnDeviceUnavailableError(error)
+                ) {
                     this._domOnDeviceUnavailable = true;
                     if (this._domTranslationQueue) this._domTranslationQueue.length = 0;
                 }

--- a/packages/EdgeTranslate/src/options/options.html
+++ b/packages/EdgeTranslate/src/options/options.html
@@ -230,6 +230,23 @@
                             />
                         </label>
                     </div>
+                    <div class="column">
+                        <label
+                            for="local-translator-timeout"
+                            class="checked-label i18n"
+                            data-i18n-name="LocalTranslatorTimeoutMs"
+                            data-insert-pos="afterBegin"
+                        >
+                            <input
+                                type="number"
+                                setting-type="text"
+                                setting-path="LocalTranslatorConfig timeoutMs"
+                                id="local-translator-timeout"
+                                min="1000"
+                                step="1000"
+                            />
+                        </label>
+                    </div>
                 </div>
                 <p class="i18n" data-i18n-name="LocalTranslatorHelp"></p>
 
@@ -328,6 +345,23 @@
                                 class="radio"
                                 name="default-page-translator"
                                 id="chrome-builtin-page-translator"
+                            />
+                        </label>
+                    </div>
+                    <div class="column">
+                        <label
+                            for="local-page-translator"
+                            class="checked-label i18n"
+                            data-i18n-name="LocalPageTranslate"
+                        >
+                            <input
+                                type="radio"
+                                value="LocalPageTranslate"
+                                setting-type="radio"
+                                setting-path="DefaultPageTranslator"
+                                class="radio"
+                                name="default-page-translator"
+                                id="local-page-translator"
                             />
                         </label>
                     </div>

--- a/packages/EdgeTranslate/static/_locales/en/messages.json
+++ b/packages/EdgeTranslate/static/_locales/en/messages.json
@@ -1325,5 +1325,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome Built-in Translator Page Translate"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "Local translator timeout (ms)"
+    },
+    "LocalPageTranslate": {
+        "message": "Local Translator Page Translate"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ja/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ja/messages.json
@@ -1325,5 +1325,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 組み込み翻訳ページ翻訳"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "ローカル翻訳タイムアウト(ms)"
+    },
+    "LocalPageTranslate": {
+        "message": "ローカル翻訳ページ翻訳"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ko/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ko/messages.json
@@ -485,5 +485,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 내장 번역기 페이지 번역"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "로컬 번역기 제한 시간(ms)"
+    },
+    "LocalPageTranslate": {
+        "message": "로컬 번역기 페이지 번역"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/ru/messages.json
+++ b/packages/EdgeTranslate/static/_locales/ru/messages.json
@@ -1325,5 +1325,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Перевод страницы встроенным переводчиком Chrome"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "Тайм-аут локального переводчика (мс)"
+    },
+    "LocalPageTranslate": {
+        "message": "Перевод страницы локальным переводчиком"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_CN/messages.json
@@ -1325,5 +1325,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 内置翻译器网页翻译"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "本地翻译超时（毫秒）"
+    },
+    "LocalPageTranslate": {
+        "message": "本地翻译器网页翻译"
     }
 }

--- a/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
+++ b/packages/EdgeTranslate/static/_locales/zh_TW/messages.json
@@ -1325,5 +1325,11 @@
     },
     "ChromeBuiltinPageTranslate": {
         "message": "Chrome 內建翻譯器網頁翻譯"
+    },
+    "LocalTranslatorTimeoutMs": {
+        "message": "本機翻譯逾時（毫秒）"
+    },
+    "LocalPageTranslate": {
+        "message": "本機翻譯器網頁翻譯"
     }
 }

--- a/packages/translators/src/translators/local.ts
+++ b/packages/translators/src/translators/local.ts
@@ -9,7 +9,7 @@ export type LocalTranslatorConfig = {
     mode?: LocalTranslatorMode | string;
     endpoint?: string;
     apiKey?: string;
-    timeoutMs?: number;
+    timeoutMs?: number | string;
 };
 
 const LANGUAGE_NAMES: Record<string, string> = {
@@ -172,7 +172,7 @@ class LocalTranslator {
         this.mode = normalizeMode(config.mode);
         this.endpoint = normalizeEndpoint(config.endpoint);
         this.apiKey = (config.apiKey || "").trim();
-        this.timeoutMs = config.timeoutMs || DEFAULT_TIMEOUT_MS;
+        this.timeoutMs = Number(config.timeoutMs) || DEFAULT_TIMEOUT_MS;
         this.cache.clear();
         this.inflight.clear();
         this.chromeTranslatorCache.clear();


### PR DESCRIPTION
## Summary
- Add `LocalPageTranslate` so page translation can use the configured LocalTranslate endpoint instead of only Google/Chrome built-in paths.
- Reuse the existing DOM grouping queue for local endpoint page translation and cap local chunks at ~1400 chars for faster perceived progress with CPU local LLMs.
- Add a configurable local translator timeout (default 120s) and expose it in options.
- Add localized labels for the new page translator and timeout setting.

## Test Plan
- `npm run build:chrome`
- `npm test`
